### PR TITLE
1346 empty routes path redirection

### DIFF
--- a/bot/admin/web/src/app/bot/bot.module.ts
+++ b/bot/admin/web/src/app/bot/bot.module.ts
@@ -82,8 +82,9 @@ const routes: Routes = [
     },
     children: [
       {
-        path: '',
-        component: CreateStoryComponent
+        path: '', 
+        redirectTo: 'story-create', 
+        pathMatch: 'full'
       },
       {
         path: 'story-create',

--- a/bot/admin/web/src/app/shared/bot-shared.service.ts
+++ b/bot/admin/web/src/app/shared/bot-shared.service.ts
@@ -63,7 +63,7 @@ export class BotSharedService implements OnDestroy {
     return this.rest.get(`/action/nlp-stats/${actionId}`, NlpCallStats.fromJSON)
   }
 
-  getConfigurationPending
+  getConfigurationPending: Observable<AdminConfiguration>
   getConfiguration(): Observable<AdminConfiguration> {
     if(this.configuration) {
       return of(this.configuration);

--- a/bot/admin/web/src/app/shared/bot-shared.service.ts
+++ b/bot/admin/web/src/app/shared/bot-shared.service.ts
@@ -15,7 +15,7 @@
  */
 
 
-import {tap} from 'rxjs/operators';
+import {share, tap} from 'rxjs/operators';
 import {Injectable, OnDestroy} from "@angular/core";
 import {RestService} from "../core-nlp/rest/rest.service";
 import {Observable, of} from "rxjs";
@@ -63,11 +63,15 @@ export class BotSharedService implements OnDestroy {
     return this.rest.get(`/action/nlp-stats/${actionId}`, NlpCallStats.fromJSON)
   }
 
+  getConfigurationPending
   getConfiguration(): Observable<AdminConfiguration> {
     if(this.configuration) {
       return of(this.configuration);
     } else {
-      return this.rest.get(`/configuration`, AdminConfiguration.fromJSON);
+      if(!this.getConfigurationPending) {
+        this.getConfigurationPending = this.rest.get(`/configuration`, AdminConfiguration.fromJSON).pipe(share());
+      }
+      return this.getConfigurationPending
     }
   }
 

--- a/bot/admin/web/src/app/test/test.module.ts
+++ b/bot/admin/web/src/app/test/test.module.ts
@@ -49,7 +49,8 @@ const routes: Routes = [
     children: [
       {
         path: '',
-        component: BotDialogComponent
+        redirectTo: 'test', 
+        pathMatch: 'full'
       },
       {
         path: 'test',

--- a/nlp/admin/web/src/app/core-nlp/applications.service.ts
+++ b/nlp/admin/web/src/app/core-nlp/applications.service.ts
@@ -15,7 +15,7 @@
  */
 
 
-import {map} from 'rxjs/operators';
+import {map, share} from 'rxjs/operators';
 import {Injectable, OnDestroy} from "@angular/core";
 import {Observable, of} from "rxjs";
 import {
@@ -72,8 +72,14 @@ export class ApplicationService implements OnDestroy {
     });
   }
 
+  getApplicationsPending: Observable<Application[]>
   getApplications(): Observable<Application[]> {
-    return this.rest.getArray("/applications", Application.fromJSONArray);
+    if(!this.getApplicationsPending){
+      this.getApplicationsPending = this.rest.getArray("/applications", Application.fromJSONArray).pipe(
+        share()
+      )
+    }
+    return this.getApplicationsPending
   }
 
   nlpEngineTypes(): Observable<NlpEngineType[]> {

--- a/nlp/admin/web/src/app/nlp-tabs/nlp.module.ts
+++ b/nlp/admin/web/src/app/nlp-tabs/nlp.module.ts
@@ -77,8 +77,9 @@ const routes: Routes = [
     },
     children: [
       {
-        path: '',
-        component: InboxComponent
+        path: '', 
+        redirectTo: 'inbox', 
+        pathMatch: 'full'
       },
       {
         path: 'try',

--- a/nlp/admin/web/src/app/quality-nlp/quality.module.ts
+++ b/nlp/admin/web/src/app/quality-nlp/quality.module.ts
@@ -51,8 +51,9 @@ const routes: Routes = [
     },
     children: [
       {
-        path: '',
-        component: TestBuildsComponent
+        path: '', 
+        redirectTo: 'test-builds', 
+        pathMatch: 'full'
       },
       {
         path: 'log-stats',


### PR DESCRIPTION
Les 3 premiers commits suppriment qqs appels superflus aux endpoints depuis les routes de modules. Le 4eme évite la double requete de /rest/admin/applications au bootstrap en partageant l'observable de l'appel rest entre les appels successifs. 