### PR TITLE
1168 faq UI with new roles support

### DIFF
--- a/bot/admin/server/src/main/kotlin/BotAdminVerticle.kt
+++ b/bot/admin/server/src/main/kotlin/BotAdminVerticle.kt
@@ -94,124 +94,115 @@ open class BotAdminVerticle : AdminVerticle() {
             }
         }
 
-        blockingJsonPost("/analytics/messages", botUser) { context, request: DialogFlowRequest ->
+        blockingJsonPost("/analytics/messages",setOf(botUser,faqBotUser)) { context, request: DialogFlowRequest ->
             if (context.organization == request.namespace) {
                 measureTimeMillis(
-                    context,
-                    {
-                        BotAdminService.reportMessagesByType(request)
-                    }
-                )
+                    context
+                ) {
+                    BotAdminService.reportMessagesByType(request)
+                }
             } else {
                 unauthorized()
             }
         }
 
-        blockingJsonPost("/analytics/users", botUser) { context, request: DialogFlowRequest ->
+        blockingJsonPost("/analytics/users",setOf(botUser,faqBotUser)) { context, request: DialogFlowRequest ->
             if (context.organization == request.namespace) {
                 measureTimeMillis(
-                    context,
-                    {
-                        BotAdminService.reportUsersByType(request)
-                    }
-                )
+                    context
+                ) {
+                    BotAdminService.reportUsersByType(request)
+                }
             } else {
                 unauthorized()
             }
         }
 
-        blockingJsonPost("/analytics/messages/byConfiguration", botUser) { context, request: DialogFlowRequest ->
+        blockingJsonPost("/analytics/messages/byConfiguration",setOf(botUser,faqBotUser)) { context, request: DialogFlowRequest ->
             if (context.organization == request.namespace) {
                 measureTimeMillis(
-                    context,
-                    {
-                        BotAdminService.reportMessagesByConfiguration(request)
-                    }
-                )
+                    context
+                ) {
+                    BotAdminService.reportMessagesByConfiguration(request)
+                }
             } else {
                 unauthorized()
             }
         }
 
-        blockingJsonPost("/analytics/messages/byConnectorType", botUser) { context, request: DialogFlowRequest ->
+        blockingJsonPost("/analytics/messages/byConnectorType",setOf(botUser,faqBotUser)) { context, request: DialogFlowRequest ->
             if (context.organization == request.namespace) {
                 measureTimeMillis(
-                    context,
-                    {
-                        BotAdminService.reportMessagesByConnectorType(request)
-                    }
-                )
+                    context
+                ) {
+                    BotAdminService.reportMessagesByConnectorType(request)
+                }
             } else {
                 unauthorized()
             }
         }
 
-        blockingJsonPost("/analytics/messages/byDayOfWeek", botUser) { context, request: DialogFlowRequest ->
+        blockingJsonPost("/analytics/messages/byDayOfWeek",setOf(botUser,faqBotUser)) { context, request: DialogFlowRequest ->
             if (context.organization == request.namespace) {
                 measureTimeMillis(
-                    context,
-                    {
-                        BotAdminService.reportMessagesByDayOfWeek(request)
-                    }
-                )
+                    context
+                ) {
+                    BotAdminService.reportMessagesByDayOfWeek(request)
+                }
             } else {
                 unauthorized()
             }
         }
 
-        blockingJsonPost("/analytics/messages/byHour", botUser) { context, request: DialogFlowRequest ->
+        blockingJsonPost("/analytics/messages/byHour",setOf(botUser,faqBotUser)) { context, request: DialogFlowRequest ->
             if (context.organization == request.namespace) {
                 measureTimeMillis(
-                    context,
-                    {
-                        BotAdminService.reportMessagesByHour(request)
-                    }
-                )
+                    context
+                ) {
+                    BotAdminService.reportMessagesByHour(request)
+                }
             } else {
                 unauthorized()
             }
         }
 
-        blockingJsonPost("/analytics/messages/byDateAndIntent", botUser) { context, request: DialogFlowRequest ->
+        blockingJsonPost("/analytics/messages/byDateAndIntent",setOf(botUser,faqBotUser)) { context, request: DialogFlowRequest ->
             if (context.organization == request.namespace) {
                 measureTimeMillis(
-                    context,
-                    {
-                        BotAdminService.reportMessagesByDateAndIntent(request)
-                    }
-                )
+                    context
+                ) {
+                    BotAdminService.reportMessagesByDateAndIntent(request)
+                }
             } else {
                 unauthorized()
             }
         }
 
-        blockingJsonPost("/analytics/messages/byIntent", botUser) { context, request: DialogFlowRequest ->
+        blockingJsonPost("/analytics/messages/byIntent",setOf(botUser,faqBotUser)) { context, request: DialogFlowRequest ->
             if (context.organization == request.namespace) {
                 measureTimeMillis(
-                    context,
-                    {
-                        BotAdminService.reportMessagesByIntent(request)
-                    }
-                )
+                    context
+                ) {
+                    BotAdminService.reportMessagesByIntent(request)
+                }
             } else {
                 unauthorized()
             }
         }
 
-        blockingJsonPost("/analytics/messages/byDateAndStory", botUser) { context, request: DialogFlowRequest ->
+        blockingJsonPost("/analytics/messages/byDateAndStory",setOf(botUser,faqBotUser)) { context, request: DialogFlowRequest ->
             if (context.organization == request.namespace) {
                 measureTimeMillis(
-                    context,
-                    {
-                        BotAdminService.reportMessagesByDateAndStory(request)
-                    }
-                )
+                    context
+                ) {
+                    BotAdminService.reportMessagesByDateAndStory(request)
+                }
             } else {
                 unauthorized()
             }
         }
 
-        blockingJsonPost("/analytics/messages/byStory", botUser) { context, request: DialogFlowRequest ->
+        blockingJsonPost("/analytics/messages/byStory",setOf(botUser,faqBotUser)) { context, request: DialogFlowRequest ->
             if (context.organization == request.namespace) {
                 measureTimeMillis(
                     context,
@@ -224,7 +215,7 @@ open class BotAdminVerticle : AdminVerticle() {
             }
         }
 
-        blockingJsonPost("/analytics/messages/byStoryCategory", botUser) { context, request: DialogFlowRequest ->
+        blockingJsonPost("/analytics/messages/byStoryCategory",setOf(botUser,faqBotUser)) { context, request: DialogFlowRequest ->
             if (context.organization == request.namespace) {
                 measureTimeMillis(
                     context,
@@ -237,7 +228,7 @@ open class BotAdminVerticle : AdminVerticle() {
             }
         }
 
-        blockingJsonPost("/analytics/messages/byStoryType", botUser) { context, request: DialogFlowRequest ->
+        blockingJsonPost("/analytics/messages/byStoryType",setOf(botUser,faqBotUser)) { context, request: DialogFlowRequest ->
             if (context.organization == request.namespace) {
                 measureTimeMillis(
                     context,
@@ -250,7 +241,7 @@ open class BotAdminVerticle : AdminVerticle() {
             }
         }
 
-        blockingJsonPost("/analytics/messages/byStoryLocale", botUser) { context, request: DialogFlowRequest ->
+        blockingJsonPost("/analytics/messages/byStoryLocale",setOf(botUser,faqBotUser)) { context, request: DialogFlowRequest ->
             if (context.organization == request.namespace) {
                 measureTimeMillis(
                     context,
@@ -263,7 +254,7 @@ open class BotAdminVerticle : AdminVerticle() {
             }
         }
 
-        blockingJsonPost("/analytics/messages/byActionType", botUser) { context, request: DialogFlowRequest ->
+        blockingJsonPost("/analytics/messages/byActionType",setOf(botUser,faqBotUser)) { context, request: DialogFlowRequest ->
             if (context.organization == request.namespace) {
                 measureTimeMillis(
                     context,
@@ -295,7 +286,7 @@ open class BotAdminVerticle : AdminVerticle() {
             }
         }
 
-        blockingJsonPost("/dialogs/search", botUser) { context, query: DialogsSearchQuery ->
+        blockingJsonPost("/dialogs/search",setOf(botUser,faqNlpUser,faqBotUser)) { context, query: DialogsSearchQuery ->
             if (context.organization == query.namespace) {
                 BotAdminService.search(query)
             } else {
@@ -303,12 +294,12 @@ open class BotAdminVerticle : AdminVerticle() {
             }
         }
 
-        blockingJsonGet("/bots/:botId", botUser) { context ->
+        blockingJsonGet("/bots/:botId",setOf(botUser,faqNlpUser,faqBotUser)) { context ->
             BotAdminService.getBots(context.organization, context.path("botId"))
         }
 
         blockingJsonPost(
-            "/bot",
+            "/bot", admin,
             logger = logger<BotConfiguration>(" Create or Update Bot Configuration") { _, c ->
                 c?.let { FrontClient.getApplicationByNamespaceAndName(it.namespace, it.nlpModel)?._id }
             }
@@ -320,7 +311,7 @@ open class BotAdminVerticle : AdminVerticle() {
             }
         }
 
-        blockingJsonGet("/configuration/bots/:botId", botUser) { context ->
+        blockingJsonGet("/configuration/bots/:botId",setOf(botUser,faqBotUser)) { context ->
             BotAdminService.getBotConfigurationsByNamespaceAndBotId(context.organization, context.path("botId"))
         }
 
@@ -333,7 +324,7 @@ open class BotAdminVerticle : AdminVerticle() {
         }
 
         blockingJsonPost(
-            "/configuration/bot",
+            "/configuration/bot", admin,
             logger = logger<BotConnectorConfiguration>("Create or Update Bot Connector Configuration") { _, c ->
                 c?.let { FrontClient.getApplicationByNamespaceAndName(it.namespace, it.nlpModel)?._id }
             }
@@ -433,18 +424,18 @@ open class BotAdminVerticle : AdminVerticle() {
                 } ?: unauthorized()
         }
 
-        blockingJsonGet("/action/nlp-stats/:actionId", botUser) { context ->
+        blockingJsonGet("/action/nlp-stats/:actionId",setOf(botUser,faqBotUser)) { context ->
             dialogReportDAO.getNlpCallStats(context.pathId("actionId"), context.organization)
         }
 
-        blockingJsonGet("/feature/:applicationId", botUser) { context ->
+        blockingJsonGet("/feature/:applicationId",setOf(botUser,faqBotUser)) { context ->
             val applicationId = context.path("applicationId")
             BotAdminService.getFeatures(applicationId, context.organization)
         }
 
         blockingPost(
             "/feature/:applicationId/toggle",
-            botUser,
+           setOf(botUser,faqBotUser),
             simpleLogger("Toogle Application Feature", { it.bodyAsString })
         ) { context ->
             val applicationId = context.path("applicationId")
@@ -455,7 +446,7 @@ open class BotAdminVerticle : AdminVerticle() {
 
         blockingPost(
             "/feature/:applicationId/update",
-            botUser,
+           setOf(botUser,faqBotUser),
             simpleLogger("Update Application Feature", { it.bodyAsString })
         ) { context ->
             val applicationId = context.path("applicationId")
@@ -470,7 +461,7 @@ open class BotAdminVerticle : AdminVerticle() {
 
         blockingPost(
             "/feature/:applicationId/add",
-            botUser,
+           setOf(botUser,faqBotUser),
             simpleLogger("Create Application Feature", { it.bodyAsString })
         ) { context ->
             val applicationId = context.path("applicationId")
@@ -481,7 +472,7 @@ open class BotAdminVerticle : AdminVerticle() {
 
         blockingDelete(
             "/feature/:botId/:category/:name/",
-            botUser,
+           botUser,
             simpleLogger(
                 "Delete Application Feature",
                 { listOf(it.path("botId"), it.path("category"), it.path("name")) }
@@ -495,7 +486,7 @@ open class BotAdminVerticle : AdminVerticle() {
 
         blockingDelete(
             "/feature/:botId/:category/:name/:applicationId",
-            botUser,
+           botUser,
             simpleLogger(
                 "Delete Application Feature",
                 { listOf(it.path("botId"), it.path("category"), it.path("name"), it.path("applicationId")) }
@@ -529,7 +520,7 @@ open class BotAdminVerticle : AdminVerticle() {
 
         blockingJsonPost(
             "/bot/story/new",
-            botUser,
+            setOf(botUser,faqBotUser),
             logger<CreateStoryRequest>("Create Story") { context, r ->
                 r?.story?.let { s ->
                     BotAdminService.getBotConfigurationsByNamespaceAndBotId(context.organization, s.botId)
@@ -570,7 +561,7 @@ open class BotAdminVerticle : AdminVerticle() {
 
         blockingJsonPost(
             "/bot/story",
-            botUser,
+            setOf(botUser,faqBotUser),
             logger<BotStoryDefinitionConfiguration>("Update Story") { context, r ->
                 r?.let { s ->
                     getBotConfigurationsByNamespaceAndBotId(context.organization, s.botId)
@@ -582,7 +573,7 @@ open class BotAdminVerticle : AdminVerticle() {
             BotAdminService.saveStory(context.organization, story, context.userLogin) ?: unauthorized()
         }
 
-        blockingJsonPost("/bot/story/load", botUser) { context, request: StorySearchRequest ->
+        blockingJsonPost("/bot/story/load", setOf(botUser,faqBotUser)) { context, request: StorySearchRequest ->
             if (context.organization == request.namespace) {
                 BotAdminService.loadStories(request)
             } else {
@@ -590,7 +581,7 @@ open class BotAdminVerticle : AdminVerticle() {
             }
         }
 
-        blockingJsonPost("/bot/story/search", botUser) { context, request: StorySearchRequest ->
+        blockingJsonPost("/bot/story/search", setOf(botUser,faqBotUser)) { context, request: StorySearchRequest ->
             if (context.organization == request.namespace) {
                 BotAdminService.searchStories(request)
             } else {
@@ -598,7 +589,7 @@ open class BotAdminVerticle : AdminVerticle() {
             }
         }
 
-        blockingJsonGet("/bot/story/:storyId", botUser) { context ->
+        blockingJsonGet("/bot/story/:storyId", setOf(botUser,faqBotUser)) { context ->
             BotAdminService.findStory(context.organization, context.path("storyId"))
         }
 
@@ -616,7 +607,7 @@ open class BotAdminVerticle : AdminVerticle() {
 
         blockingJsonDelete(
             "/bot/story/:storyId",
-            botUser,
+            setOf(botUser,faqBotUser),
             simpleLogger("Delete Story", { it.path("storyId") })
         ) { context ->
             BotAdminService.deleteStory(context.organization, context.path("storyId"))
@@ -635,7 +626,7 @@ open class BotAdminVerticle : AdminVerticle() {
             }
         }
 
-        blockingJsonGet("/i18n", botUser) { context ->
+        blockingJsonGet("/i18n", setOf(botUser,faqBotUser)) { context ->
             val stats = i18n.getLabelStats(context.organization).groupBy { it.labelId }
             BotI18nLabels(
                 i18n
@@ -651,7 +642,7 @@ open class BotAdminVerticle : AdminVerticle() {
 
         blockingJsonPost(
             "/i18n/complete",
-            botUser,
+            setOf(botUser,faqBotUser),
             simpleLogger("Complete Responses Labels")
         ) { context, labels: List<I18nLabel> ->
             if (!injector.provide<TranslatorEngine>().supportAdminTranslation) {
@@ -662,7 +653,7 @@ open class BotAdminVerticle : AdminVerticle() {
 
         blockingJsonPost(
             "/i18n/saveAll",
-            botUser,
+            setOf(botUser,faqBotUser),
             simpleLogger("Save Responses Labels")
         ) { context, labels: List<I18nLabel> ->
             i18n.save(labels.filter { it.namespace == context.organization })
@@ -670,7 +661,7 @@ open class BotAdminVerticle : AdminVerticle() {
 
         blockingJsonPost(
             "/i18n/save",
-            botUser,
+            setOf(botUser,faqBotUser),
             simpleLogger("Save Response Label")
         ) { context, label: I18nLabel ->
             if (label.namespace == context.organization) {
@@ -682,7 +673,7 @@ open class BotAdminVerticle : AdminVerticle() {
 
         blockingJsonPost(
             "/i18n/create",
-            botUser,
+            setOf(botUser,faqBotUser),
             simpleLogger("Create Response Label")
         ) { context, request: CreateI18nLabelRequest ->
             createI18nRequest(context.organization, request)
@@ -690,17 +681,17 @@ open class BotAdminVerticle : AdminVerticle() {
 
         blockingDelete(
             "/i18n/:id",
-            botUser,
+            setOf(botUser,faqBotUser),
             simpleLogger("Delete Response Label", { it.path("id") })
         ) { context ->
             i18n.deleteByNamespaceAndId(context.organization, context.pathId("id"))
         }
 
-        blockingJsonGet("/i18n/export/csv", botUser) { context ->
+        blockingJsonGet("/i18n/export/csv", setOf(botUser,faqBotUser)) { context ->
             I18nCsvCodec.exportCsv(context.organization)
         }
 
-        blockingJsonPost("/i18n/export/csv", botUser) { context, query: I18LabelQuery ->
+        blockingJsonPost("/i18n/export/csv", setOf(botUser,faqBotUser)) { context, query: I18LabelQuery ->
             I18nCsvCodec.exportCsv(context.organization, query)
         }
 
@@ -714,18 +705,18 @@ open class BotAdminVerticle : AdminVerticle() {
             }
         }
 
-        blockingJsonGet("/i18n/export/json", botUser) { context ->
+        blockingJsonGet("/i18n/export/json", setOf(botUser,faqBotUser)) { context ->
             mapper.writeValueAsString(i18n.getLabels(context.organization))
         }
 
-        blockingJsonPost("/i18n/export/json", botUser) { context, query: I18LabelQuery ->
+        blockingJsonPost("/i18n/export/json", setOf(botUser,faqBotUser)) { context, query: I18LabelQuery ->
             val labels = i18n.getLabels(context.organization, query.toI18nLabelFilter())
             mapper.writeValueAsString(labels)
         }
 
         blockingUploadJsonPost(
             "/i18n/import/json",
-            botUser,
+            setOf(botUser,faqBotUser),
             simpleLogger("JSON Import Response Labels")
         ) { context, labels: List<I18nLabel> ->
             measureTimeMillis(context) {
@@ -758,7 +749,7 @@ open class BotAdminVerticle : AdminVerticle() {
             }
         }
 
-        blockingJsonGet("/connectorTypes", botUser) {
+        blockingJsonGet("/connectorTypes", setOf(botUser,faqBotUser,faqNlpUser)) {
             ConnectorTypeConfiguration.connectorConfigurations
         }
 
@@ -772,7 +763,7 @@ open class BotAdminVerticle : AdminVerticle() {
 
         blockingJsonPost(
             "/faq",
-            botUser,
+            setOf(botUser,faqBotUser),
             logger<FaqDefinitionRequest>("Save FAQ")
         ) { context, query: FaqDefinitionRequest ->
             if (query.utterances.isEmpty() && query.title.isBlank() && query.answer.isBlank()) {
@@ -789,13 +780,13 @@ open class BotAdminVerticle : AdminVerticle() {
 
         blockingJsonDelete(
             "/faq/:faqId",
-            botUser,
+            setOf(botUser,faqBotUser),
             simpleLogger("Delete Story", { it.path("faqId") })
         ) { context ->
             FaqAdminService.deleteFaqDefinition(context.organization, context.path("faqId"))
         }
 
-        blockingJsonPost("/faq/tags", nlpUser) { context, applicationId : String ->
+        blockingJsonPost("/faq/tags", setOf(botUser,faqBotUser)) { context, applicationId : String ->
             val applicationDefinition = BotAdminService.front.getApplicationById(applicationId.toId())
             if (context.organization == applicationDefinition?.namespace) {
                 try {
@@ -811,7 +802,8 @@ open class BotAdminVerticle : AdminVerticle() {
 
         blockingJsonPost(
             "/faq/search",
-            nlpUser, logger<FaqSearchRequest>("Search FAQ")
+            setOf(botUser,faqBotUser),
+            logger<FaqSearchRequest>("Search FAQ")
         )
         { context, request: FaqSearchRequest ->
             val applicationDefinition = BotAdminService.front.getApplicationByNamespaceAndName(request.namespace, request.applicationName)
@@ -832,7 +824,7 @@ open class BotAdminVerticle : AdminVerticle() {
 
         blockingJsonPost(
             "/faq/status",
-            nlpUser,
+            setOf(botUser,faqBotUser),
             logger<FaqDefinitionRequest>("Change FAQ status")
         ) { context, query: FaqDefinitionRequest ->
             val applicationDefinition = BotAdminService.front.getApplicationById(query.applicationId)

--- a/bot/admin/test/core/src/main/kotlin/TestCoreService.kt
+++ b/bot/admin/test/core/src/main/kotlin/TestCoreService.kt
@@ -32,7 +32,9 @@ import ai.tock.shared.error
 import ai.tock.shared.injector
 import ai.tock.shared.property
 import ai.tock.shared.provide
-import ai.tock.shared.security.TockUserRole.*
+import ai.tock.shared.security.TockUserRole.botUser
+import ai.tock.shared.security.TockUserRole.faqBotUser
+import ai.tock.shared.security.TockUserRole.faqNlpUser
 import ai.tock.shared.vertx.UnauthorizedException
 import ai.tock.shared.vertx.WebVerticle
 import ai.tock.shared.vertx.WebVerticle.Companion

--- a/bot/admin/test/core/src/main/kotlin/TestCoreService.kt
+++ b/bot/admin/test/core/src/main/kotlin/TestCoreService.kt
@@ -32,7 +32,7 @@ import ai.tock.shared.error
 import ai.tock.shared.injector
 import ai.tock.shared.property
 import ai.tock.shared.provide
-import ai.tock.shared.security.TockUserRole.botUser
+import ai.tock.shared.security.TockUserRole.*
 import ai.tock.shared.vertx.UnauthorizedException
 import ai.tock.shared.vertx.WebVerticle
 import ai.tock.shared.vertx.WebVerticle.Companion
@@ -134,7 +134,7 @@ class TestCoreService : TestService {
             }
         }
 
-        blockingJsonPost("/test/talk", botUser) { context, query: BotDialogRequest ->
+        blockingJsonPost("/test/talk", setOf(botUser,faqNlpUser,faqBotUser)) { context, query: BotDialogRequest ->
             if (context.organization == query.namespace) {
                 talk(query)
             } else {

--- a/bot/admin/web/package.json
+++ b/bot/admin/web/package.json
@@ -55,6 +55,7 @@
     "ngx-echarts": "^5.2.2",
     "ngx-infinite-scroll": "^8.0.2",
     "ngx-moment": "^5.0.0",
+    "node-sass": "^4.14.1",
     "normalize.css": "6.0.0",
     "pace-js": "1.0.2",
     "prettier": "2.6.2",

--- a/bot/admin/web/package.json
+++ b/bot/admin/web/package.json
@@ -55,7 +55,6 @@
     "ngx-echarts": "^5.2.2",
     "ngx-infinite-scroll": "^8.0.2",
     "ngx-moment": "^5.0.0",
-    "node-sass": "^4.14.1",
     "normalize.css": "6.0.0",
     "pace-js": "1.0.2",
     "prettier": "2.6.2",

--- a/bot/admin/web/src/app/analytics/analytics-tabs.component.ts
+++ b/bot/admin/web/src/app/analytics/analytics-tabs.component.ts
@@ -14,10 +14,18 @@
  * limitations under the License.
  */
 
-import { Component, OnInit } from '@angular/core';
-import { ActivatedRoute, Router, RouterState } from '@angular/router';
+import {Component, OnInit} from '@angular/core';
+import {Router} from '@angular/router';
+import {StateService} from "../core-nlp/state.service";
+import {UserRole} from "../model/auth";
+
 class TabLink {
-  constructor(public route: string, public title: string, public icon?: string) {}
+  constructor(
+    public route: string,
+    public title: string,
+    public icon?: string
+  ) {
+  }
 }
 
 const tabs = [
@@ -37,7 +45,11 @@ const tabs = [
 export class AnalyticsTabsComponent implements OnInit {
   analyticsTabLinks = tabs;
 
-  constructor(private router: Router) {}
+  constructor(private router: Router, private state: StateService) {
+    if (!state.hasRole(UserRole.botUser)) {
+      this.analyticsTabLinks = this.analyticsTabLinks.filter(t => !["flow", "users"].includes(t.route))
+    }
+  }
 
   ngOnInit() {
     if (this.router.routerState.snapshot.url.endsWith('/analytics')) {

--- a/bot/admin/web/src/app/core/bot-core.module.ts
+++ b/bot/admin/web/src/app/core/bot-core.module.ts
@@ -29,12 +29,16 @@ export class BotCoreConfig implements CoreConfig {
   /** url to answer to sentence if it exists */
   answerToSentenceUrl: string = '/build/story-create';
   /** url map for each default rights */
-  roleMap: Map<UserRole, string> = new Map([
-    [UserRole.nlpUser, '/nlp'],
-    [UserRole.botUser, '/build'],
-    [UserRole.admin, '/configuration'],
-    [UserRole.technicalAdmin, '/configuration']
-  ]);
+  roleMap: Map<UserRole, string> = new Map(
+    [
+      [UserRole.nlpUser, "/nlp"],
+      [UserRole.faqNlpUser, "/faq/train"],
+      [UserRole.faqBotUser, "/faq/qa"],
+      [UserRole.botUser, "/build"],
+      [UserRole.admin, "/configuration"],
+      [UserRole.technicalAdmin, "/configuration"],
+    ]);
+
 }
 
 @NgModule({

--- a/bot/admin/web/src/app/faq/common/faq-definition.service.ts
+++ b/bot/admin/web/src/app/faq/common/faq-definition.service.ts
@@ -56,6 +56,8 @@ export class FaqDefinitionService {
     return this.rest.delete(`/faq/${fq.id}`).pipe(
       takeUntil(cancel$),
       map(r => {
+        //delete to current state
+        this.state.resetConfiguration()
         if (r) {
           this.faqData.rows = this.faqData.rows.map(item => {
             if (fq.id && item.id === fq.id) {
@@ -65,7 +67,6 @@ export class FaqDefinitionService {
             } else {
               return item;
             }
-
           });
           return r
         }

--- a/bot/admin/web/src/app/faq/faq-definition/faq-definition.component.html
+++ b/bot/admin/web/src/app/faq/faq-definition/faq-definition.component.html
@@ -14,7 +14,10 @@
   ~ limitations under the License.
   -->
 
-  <h5 class="h5 mb-4">FAQ Content Management</h5>
+  <div class="title-faq mb-4" *ngIf="!isDockedOrSmall()">
+      <h5 class="h5 mr-4">FAQ Content Management</h5>
+      <button (click)="openNewSidepanel()" nbButton status="primary">New FAQ</button>
+  </div>
 
   <nb-alert
     *ngIf="configurations?.length === 0"

--- a/bot/admin/web/src/app/faq/faq-definition/faq-definition.component.scss
+++ b/bot/admin/web/src/app/faq/faq-definition/faq-definition.component.scss
@@ -43,6 +43,12 @@
 
 }
 
+.title-faq{
+  display: flex;
+  flex-wrap: nowrap;
+  flex-direction: row;
+}
+
 .tock-form-problems {
   position: absolute;
   user-select: none;

--- a/bot/admin/web/src/app/faq/faq-definition/faq-definition.component.ts
+++ b/bot/admin/web/src/app/faq/faq-definition/faq-definition.component.ts
@@ -20,6 +20,7 @@ import {ReplaySubject, Subscription} from 'rxjs';
 import {takeUntil} from "rxjs/operators";
 
 import {StateService} from 'src/app/core-nlp/state.service';
+import {isDockedOrSmall} from '../common/model/view-mode';
 import {DEFAULT_PANEL_NAME, WithSidePanel} from '../common/mixin/with-side-panel';
 import {blankFaqDefinition, FaqDefinition} from '../common/model/faq-definition';
 import {FaqQaFilter, FaqGridComponent} from './faq-grid/faq-grid.component';
@@ -183,6 +184,10 @@ export class FaqDefinitionComponent extends WithSidePanel() implements OnInit, O
       truncate(fq.title || ''), {duration: 2000, status: "basic"});
 
     this.grid.refresh();
+  }
+
+  isDockedOrSmall(): boolean {
+    return isDockedOrSmall(this.viewMode);
   }
 
 }

--- a/bot/admin/web/src/app/faq/faq-definition/faq-header/faq-header.component.html
+++ b/bot/admin/web/src/app/faq/faq-definition/faq-header/faq-header.component.html
@@ -57,25 +57,6 @@
         <nb-checkbox [checked]="activationStatus" [indeterminate]="activationStatus === null" [ngModel]="activationStatus" (ngModelChange)="toggleFaqActivationSearch($event)">Active
         </nb-checkbox>
       </div>
-
-      <div class="col-md-2 mt-1 mb-1">
-        <div *ngIf="!isDockedOrSmall()">
-          <!-- NOT YET IMPLEMENTED-->
-          <!--      <button class="mr-2" nbButton status="basic">Export FAQ</button>-->
-          <!--      <button (click)="importFaq()" class="mr-2" nbButton status="basic">Import FAQ</button>-->
-          <button (click)="newFaqDefinition()" nbButton status="primary">New FAQ</button>
-        </div>
-
-        <nb-icon
-          *ngIf="isDockedOrSmall()"
-          [ngClass]="'tock-burger-icon'"
-          [nbPopover]="menu"
-          nbPopoverPlacement="bottom"
-          nbPrefix
-          pack="material-icons"
-          icon="view_headline">
-        </nb-icon>
-      </div>
     </nb-card-body>
   </nb-card>
 

--- a/bot/admin/web/src/app/test/test-tabs.component.ts
+++ b/bot/admin/web/src/app/test/test-tabs.component.ts
@@ -16,8 +16,15 @@
 
 import { Component, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
+import { StateService } from '../core-nlp/state.service';
+import { UserRole } from '../model/auth';
+
 class TabLink {
-  constructor(public route: string, public title: string, public icon?: string) {}
+  constructor(
+    public route: string,
+    public title: string,
+    public icon?: string
+  ) { }
 }
 
 const tabs = [
@@ -33,7 +40,11 @@ const tabs = [
 export class TestTabsComponent implements OnInit {
   testTabLinks = tabs;
 
-  constructor(private router: Router) {}
+  constructor(private router: Router, private state: StateService) {
+    if (!state.hasRole(UserRole.botUser)) {
+      this.testTabLinks = this.testTabLinks.filter(t => t.route !== 'plan')
+    }
+  }
 
   ngOnInit() {
     if (this.router.routerState.snapshot.url.endsWith('/test')) {

--- a/bot/engine/src/main/kotlin/engine/user/UserState.kt
+++ b/bot/engine/src/main/kotlin/engine/user/UserState.kt
@@ -38,8 +38,8 @@ data class UserState(
         private const val PROFILE_REFRESHED_FLAG = "tock_profile_refreshed"
         private const val BOT_DISABLED_FLAG = "tock_bot_disabled"
 
-        private val refreshDuration = longProperty("tock_bot_refresh_profil_duration_in_minutes", 60 * 24 * 5)
-        private val disabledDuration = longProperty("tock_bot_disabled_duration_in_minutes", 60 * 24 * 5)
+        private val refreshDuration = longProperty("tock_bot_refresh_profil_duration_in_minutes", (60 * 24 * 5).toLong())
+        private val disabledDuration = longProperty("tock_bot_disabled_duration_in_minutes", (60 * 24 * 5).toLong())
     }
 
     /**

--- a/bot/engine/src/main/kotlin/engine/user/UserState.kt
+++ b/bot/engine/src/main/kotlin/engine/user/UserState.kt
@@ -38,8 +38,8 @@ data class UserState(
         private const val PROFILE_REFRESHED_FLAG = "tock_profile_refreshed"
         private const val BOT_DISABLED_FLAG = "tock_bot_disabled"
 
-        private val refreshDuration = longProperty("tock_bot_refresh_profil_duration_in_minutes", (60 * 24 * 5).toLong())
-        private val disabledDuration = longProperty("tock_bot_disabled_duration_in_minutes", (60 * 24 * 5).toLong())
+        private val refreshDuration: Long = longProperty("tock_bot_refresh_profil_duration_in_minutes", 60 * 24 * 5)
+        private val disabledDuration: Long = longProperty("tock_bot_disabled_duration_in_minutes", 60 * 24 * 5)
     }
 
     /**

--- a/docs/_fr/admin/securite.md
+++ b/docs/_fr/admin/securite.md
@@ -39,12 +39,14 @@ un ou plusieurs de ces rôles, lui donnant différents accès dans l'application
 
 Les rôles disponibles sont définis dans l'enum `TockUserRole`:
 
-| Rôle             | Description                                   |
-|------------------|-----------------------------------------------|
-| `nlpUser` | NLP platform user, allowed to qualify and search sentences. |
-| `botUser` | Bot platform user, allowed to create and modify stories, rules and answers.  |
-| `admin` | Allowed to update applications and configurations/connectors, import/export intents, sentences, stories, etc.. |
-| `technicalAdmin` | Allowed to access encrypted data, import/export application dumps, etc. |
+| Rôle             | Description                                                                                                    |
+|------------------|----------------------------------------------------------------------------------------------------------------|
+| `nlpUser`        | NLP platform user, allowed to qualify and search sentences.                                                    |
+| `faqNlpUser`     | FAQ NLP platform user, allowed to qualify and search sentences.                                                |
+| `faqBotUser`     | A faq bot user is allowed to manage the FAQ content, and train the FAQ                                            |
+| `botUser`        | Bot platform user, allowed to create and modify stories, rules and answers.                                    |
+| `admin`          | Allowed to update applications and configurations/connectors, import/export intents, sentences, stories, etc.. |
+| `technicalAdmin` | Allowed to access encrypted data, import/export application dumps, etc.                                        |
 
 La manière de configurer quel utilisateur _Tock Studio_ a quel rôle dépend du mode d'authentification, 
 autrement dit l'implémentation de `TockAuthProvider` utilisée.
@@ -158,7 +160,7 @@ Voici les propriétés et leurs valeurs par défaut :
 Ci-dessous un exemple au format Docker-Compose :
 
 ```yaml
-{ "name" : "tock_jwt_custom_roles_mapping", "value" : "MY_USER_GROUP=nlpUser,botUser|MY_ADMIN_GROUP=nlpUser,botUser,admin,technicalAdmin" },
+{ "name" : "tock_jwt_custom_roles_mapping", "value" : "MY_USER_GROUP=nlpUser,botUser|MY_ADMIN_GROUP=nlpUser,botUser,faqNlpUser,faqBotUser,admin,technicalAdmin" },
 ```
 
 Dans cet exemple, les utilisateurs appartenant au groupe `MY_USER_GROUP` possèdent les rôles `nlpUser` et `botUser`, 

--- a/nlp/admin/server/src/main/kotlin/AdminVerticle.kt
+++ b/nlp/admin/server/src/main/kotlin/AdminVerticle.kt
@@ -310,7 +310,7 @@ open class AdminVerticle : WebVerticle() {
 
         blockingJsonGet(
             "/sentence/users/:applicationId",
-            nlpUser
+            setOf(nlpUser,faqNlpUser)
         ) { context ->
             val id: Id<ApplicationDefinition> = context.pathId("applicationId")
             if (context.organization == front.getApplicationById(id)?.namespace) {
@@ -538,7 +538,7 @@ open class AdminVerticle : WebVerticle() {
                 .sortedBy { it.second }
         }
 
-        blockingJsonPost("/parse", nlpUser) { context, query: ParseQuery ->
+        blockingJsonPost("/parse", setOf(nlpUser,faqNlpUser)) { context, query: ParseQuery ->
             if (context.organization == query.namespace) {
                 service.parseSentence(query)
             } else {
@@ -548,7 +548,7 @@ open class AdminVerticle : WebVerticle() {
 
         blockingJsonPost(
             "/sentence",
-            nlpUser,
+            setOf(nlpUser,faqNlpUser),
             logger<SentenceReport>("Update Sentence") { _, s ->
                 s?.applicationId
             }
@@ -560,7 +560,7 @@ open class AdminVerticle : WebVerticle() {
             }
         }
 
-        blockingJsonPost("/sentences/search", nlpUser) { context, s: SearchQuery ->
+        blockingJsonPost("/sentences/search", setOf(faqNlpUser,nlpUser)) { context, s: SearchQuery ->
             if (context.organization == s.namespace) {
                 try {
                     service.searchSentences(s)
@@ -791,7 +791,7 @@ open class AdminVerticle : WebVerticle() {
             }
         }
 
-        blockingJsonPost("/test/intent-errors", nlpUser) { context, query: TestBuildQuery ->
+        blockingJsonPost("/test/intent-errors", setOf(nlpUser,faqNlpUser)) { context, query: TestBuildQuery ->
             if (context.organization == query.namespace) {
                 val app = front.getApplicationByNamespaceAndName(query.namespace, query.applicationName)
                     ?: error("application for $query not found")
@@ -803,7 +803,7 @@ open class AdminVerticle : WebVerticle() {
 
         blockingJsonPost(
             "/test/intent-error/delete",
-            nlpUser,
+            setOf(nlpUser,faqNlpUser),
             logger<IntentTestErrorWithSentenceReport>("Delete Intent Test Error") { _, e -> e?.sentence?.applicationId }
         ) { context, error: IntentTestErrorWithSentenceReport ->
             if (context.organization == front.getApplicationById(error.sentence.applicationId)?.namespace) {
@@ -817,7 +817,7 @@ open class AdminVerticle : WebVerticle() {
             }
         }
 
-        blockingJsonPost("/test/entity-errors", nlpUser) { context, query: TestBuildQuery ->
+        blockingJsonPost("/test/entity-errors", setOf(nlpUser,faqNlpUser)) { context, query: TestBuildQuery ->
             if (context.organization == query.namespace) {
                 val app = front.getApplicationByNamespaceAndName(query.namespace, query.applicationName)
                     ?: error("application for $query not found")
@@ -829,7 +829,7 @@ open class AdminVerticle : WebVerticle() {
 
         blockingJsonPost(
             "/test/entity-error/delete",
-            nlpUser,
+            setOf(nlpUser,faqNlpUser),
             logger<EntityTestErrorWithSentenceReport>("Delete Entity Test Error") { _, e -> e?.sentence?.applicationId }
         ) { context, error: EntityTestErrorWithSentenceReport ->
             if (context.organization == front.getApplicationById(error.sentence.applicationId)?.namespace) {
@@ -843,7 +843,7 @@ open class AdminVerticle : WebVerticle() {
             }
         }
 
-        blockingJsonPost("/test/stats", nlpUser) { context, query: TestBuildQuery ->
+        blockingJsonPost("/test/stats", setOf(nlpUser,faqNlpUser)) { context, query: TestBuildQuery ->
             val app = front.getApplicationByNamespaceAndName(
                 query.namespace,
                 query.applicationName

--- a/nlp/admin/web/src/app/core-nlp/auth/auth.guard.ts
+++ b/nlp/admin/web/src/app/core-nlp/auth/auth.guard.ts
@@ -54,14 +54,17 @@ export class AuthGuard implements CanActivate, CanActivateChild {
   private checkLogin(url: string): boolean {
     const login = this.authService.isLoggedIn();
     if (login) {
-      if (
-        (!this.userState.hasRole(UserRole.nlpUser) &&
-          url.startsWith(this.rolesMap.get(UserRole.nlpUser))) ||
-        (!this.userState.hasRole(UserRole.botUser) &&
-          url.startsWith(this.rolesMap.get(UserRole.botUser)))
+      if ((!this.userState.hasRole(UserRole.nlpUser) && url.startsWith(this.rolesMap.get(UserRole.nlpUser)))
+        || (!this.userState.hasRole(UserRole.botUser) && url.startsWith(this.rolesMap.get(UserRole.botUser)))
+        || (!this.userState.hasRole(UserRole.faqBotUser) && url.startsWith(this.rolesMap.get(UserRole.faqBotUser)))
+        || (!this.userState.hasRole(UserRole.faqNlpUser) && url.startsWith(this.rolesMap.get(UserRole.faqNlpUser)))
       ) {
-        setTimeout((_) => {
-          if (this.userState.hasRole(UserRole.nlpUser)) {
+        setTimeout(_ => {
+          if (this.userState.hasRole(UserRole.faqNlpUser)) {
+            this.router.navigateByUrl(this.rolesMap.get(UserRole.faqNlpUser));
+          } else if (this.userState.hasRole(UserRole.faqBotUser)) {
+            this.router.navigateByUrl(this.rolesMap.get(UserRole.faqBotUser));
+          } else if (this.userState.hasRole(UserRole.nlpUser)) {
             this.router.navigateByUrl(this.rolesMap.get(UserRole.nlpUser));
           } else if (this.userState.hasRole(UserRole.botUser)) {
             this.router.navigateByUrl(this.rolesMap.get(UserRole.botUser));

--- a/nlp/admin/web/src/app/core-nlp/auth/auth.guard.ts
+++ b/nlp/admin/web/src/app/core-nlp/auth/auth.guard.ts
@@ -55,17 +55,16 @@ export class AuthGuard implements CanActivate, CanActivateChild {
     const login = this.authService.isLoggedIn();
     if (login) {
       if ((!this.userState.hasRole(UserRole.nlpUser) && url.startsWith(this.rolesMap.get(UserRole.nlpUser)))
-        || (!this.userState.hasRole(UserRole.botUser) && url.startsWith(this.rolesMap.get(UserRole.botUser)))
-        || (!this.userState.hasRole(UserRole.faqBotUser) && url.startsWith(this.rolesMap.get(UserRole.faqBotUser)))
-        || (!this.userState.hasRole(UserRole.faqNlpUser) && url.startsWith(this.rolesMap.get(UserRole.faqNlpUser)))
-      ) {
+      || (!this.userState.hasRole(UserRole.faqNlpUser) && url.startsWith(this.rolesMap.get(UserRole.faqNlpUser)))  
+      || (!this.userState.hasRole(UserRole.faqBotUser) && url.startsWith(this.rolesMap.get(UserRole.faqBotUser)))  
+      || (!this.userState.hasRole(UserRole.botUser) && url.startsWith(this.rolesMap.get(UserRole.botUser)))) {
         setTimeout(_ => {
-          if (this.userState.hasRole(UserRole.faqNlpUser)) {
+          if (this.userState.hasRole(UserRole.nlpUser)) {
+            this.router.navigateByUrl(this.rolesMap.get(UserRole.nlpUser));
+          } else if (this.userState.hasRole(UserRole.faqNlpUser)) {
             this.router.navigateByUrl(this.rolesMap.get(UserRole.faqNlpUser));
           } else if (this.userState.hasRole(UserRole.faqBotUser)) {
             this.router.navigateByUrl(this.rolesMap.get(UserRole.faqBotUser));
-          } else if (this.userState.hasRole(UserRole.nlpUser)) {
-            this.router.navigateByUrl(this.rolesMap.get(UserRole.nlpUser));
           } else if (this.userState.hasRole(UserRole.botUser)) {
             this.router.navigateByUrl(this.rolesMap.get(UserRole.botUser));
           } else if (this.userState.hasRole(UserRole.admin)) {

--- a/nlp/admin/web/src/app/core-nlp/auth/auth.guard.ts
+++ b/nlp/admin/web/src/app/core-nlp/auth/auth.guard.ts
@@ -54,11 +54,15 @@ export class AuthGuard implements CanActivate, CanActivateChild {
   private checkLogin(url: string): boolean {
     const login = this.authService.isLoggedIn();
     if (login) {
+      // check the user connected has the role
+      // and check there is an url present in configuration.roleMap in core.module.ts in tock-nlp-admin-web
+      // and bot-core.module.ts in tock-bot-admin
       if ((!this.userState.hasRole(UserRole.nlpUser) && url.startsWith(this.rolesMap.get(UserRole.nlpUser)))
-      || (!this.userState.hasRole(UserRole.faqNlpUser) && url.startsWith(this.rolesMap.get(UserRole.faqNlpUser)))  
-      || (!this.userState.hasRole(UserRole.faqBotUser) && url.startsWith(this.rolesMap.get(UserRole.faqBotUser)))  
+      || (!this.userState.hasRole(UserRole.faqNlpUser) && url.startsWith(this.rolesMap.get(UserRole.faqNlpUser)))
+      || (!this.userState.hasRole(UserRole.faqBotUser) && url.startsWith(this.rolesMap.get(UserRole.faqBotUser)))
       || (!this.userState.hasRole(UserRole.botUser) && url.startsWith(this.rolesMap.get(UserRole.botUser)))) {
         setTimeout(_ => {
+          // try to navigate to the url present for the role
           if (this.userState.hasRole(UserRole.nlpUser)) {
             this.router.navigateByUrl(this.rolesMap.get(UserRole.nlpUser));
           } else if (this.userState.hasRole(UserRole.faqNlpUser)) {

--- a/nlp/admin/web/src/app/core-nlp/core.module.ts
+++ b/nlp/admin/web/src/app/core-nlp/core.module.ts
@@ -14,17 +14,17 @@
  * limitations under the License.
  */
 
-import { Injectable, NgModule, Optional, SkipSelf } from '@angular/core';
-import { AuthModule } from './auth/auth.module';
-import { SettingsService } from './settings.service';
-import { CommonModule } from '@angular/common';
-import { RestModule } from './rest/rest.module';
-import { StateService } from './state.service';
-import { ApplicationService } from './applications.service';
-import { CoreConfig } from './core.config';
-import { ApplicationResolver } from './application.resolver';
-import { DialogService } from './dialog.service';
-import { UserRole } from '../model/auth';
+import {Injectable, NgModule, Optional, SkipSelf} from '@angular/core';
+import {AuthModule} from './auth/auth.module';
+import {SettingsService} from './settings.service';
+import {CommonModule} from '@angular/common';
+import {RestModule} from './rest/rest.module';
+import {StateService} from './state.service';
+import {ApplicationService} from './applications.service';
+import {CoreConfig} from './core.config';
+import {ApplicationResolver} from './application.resolver';
+import {DialogService} from './dialog.service';
+import {UserRole} from '../model/auth';
 
 @Injectable()
 export class NlpCoreConfig implements CoreConfig {
@@ -36,10 +36,13 @@ export class NlpCoreConfig implements CoreConfig {
   answerToSentenceUrl: string;
   /** url map for each default rights */
   roleMap: Map<UserRole, string> = new Map([
-    [UserRole.nlpUser, '/nlp'],
-    [UserRole.admin, '/configuration'],
-    [UserRole.technicalAdmin, '/configuration']
+    [UserRole.nlpUser, "/nlp"],
+    [UserRole.faqNlpUser, "/faq/train"],
+    [UserRole.faqBotUser, "/faq/qa"],
+    [UserRole.admin, "/configuration"],
+    [UserRole.technicalAdmin, "/configuration"],
   ]);
+
 }
 
 @NgModule({

--- a/nlp/admin/web/src/app/core-nlp/rest/rest.service.ts
+++ b/nlp/admin/web/src/app/core-nlp/rest/rest.service.ts
@@ -55,6 +55,10 @@ export class RestService {
     return this.ssologin || document.cookie.indexOf('tock-sso=') !== -1;
   }
 
+  isCas():boolean{
+    return this.isSSO() && document.cookie.indexOf("pac4jCsrfToken=") !== -1;
+  }
+
   private headers(): HttpHeaders {
     const headers = this.notAuthenticatedHeaders();
     //hack for dev env

--- a/nlp/admin/web/src/app/model/auth.ts
+++ b/nlp/admin/web/src/app/model/auth.ts
@@ -60,17 +60,15 @@ export enum UserRole {
    * A nlp user is allowed to qualify and search sentences, but not to update applications or builds.
    */
   nlpUser,
-
   /**
    *  A faq nlp user is allowed to qualify and search sentences, and train the FAQ, but not to update applications or builds.
    */
   faqNlpUser,
-
   /**
    *  A faq bot user is allowed to qualify and search sentences, and train the FAQ, but not to update applications or builds.
    */
   faqBotUser,
-  /**
+    /**
    * A bot user is allowed to modify answer & i18n, and to consult dialogs and conversations.
    */
   botUser,

--- a/nlp/admin/web/src/app/model/auth.ts
+++ b/nlp/admin/web/src/app/model/auth.ts
@@ -60,6 +60,16 @@ export enum UserRole {
    * A nlp user is allowed to qualify and search sentences, but not to update applications or builds.
    */
   nlpUser,
+
+  /**
+   *  A faq nlp user is allowed to qualify and search sentences, and train the FAQ, but not to update applications or builds.
+   */
+  faqNlpUser,
+
+  /**
+   *  A faq bot user is allowed to qualify and search sentences, and train the FAQ, but not to update applications or builds.
+   */
+  faqBotUser,
   /**
    * A bot user is allowed to modify answer & i18n, and to consult dialogs and conversations.
    */

--- a/nlp/admin/web/src/app/nlp-admin-app.component.ts
+++ b/nlp/admin/web/src/app/nlp-admin-app.component.ts
@@ -14,27 +14,28 @@
  * limitations under the License.
  */
 
-import { ChangeDetectorRef, Component, OnDestroy, OnInit } from '@angular/core';
-import { AuthService } from './core-nlp/auth/auth.service';
-import { StateService } from './core-nlp/state.service';
-import { RestService } from './core-nlp/rest/rest.service';
-import { MatIconRegistry } from '@angular/material/icon';
-import { UserRole } from './model/auth';
-import { DomSanitizer } from '@angular/platform-browser';
-import { NbMenuItem } from '@nebular/theme';
-import { DialogService } from './core-nlp/dialog.service';
-import { NbToastrService } from '@nebular/theme';
+import {ChangeDetectorRef, Component, OnDestroy, OnInit} from '@angular/core';
+import {AuthService} from './core-nlp/auth/auth.service';
+import {StateService} from './core-nlp/state.service';
+import {RestService} from './core-nlp/rest/rest.service';
+import {MatIconRegistry} from '@angular/material/icon';
+import {User, UserRole} from './model/auth';
+import {DomSanitizer} from '@angular/platform-browser';
+import {NbMenuItem, NbToastrService} from '@nebular/theme';
+import {DialogService} from './core-nlp/dialog.service';
+import {AuthListener} from './core-nlp/auth/auth.listener';
 
 @Component({
   selector: 'tock-nlp-admin-root',
   templateUrl: './nlp-admin-app.component.html',
   styleUrls: ['./nlp-admin-app.component.css']
 })
-export class NlpAdminAppComponent implements OnInit, OnDestroy {
+export class NlpAdminAppComponent implements AuthListener, OnInit, OnDestroy {
+
   UserRole = UserRole;
 
   private errorUnsuscriber: any;
-  public menu: NbMenuItem[];
+  public menu: NbMenuItem[] = [];
 
   constructor(
     public auth: AuthService,
@@ -50,32 +51,39 @@ export class NlpAdminAppComponent implements OnInit, OnDestroy {
       'logo',
       sanitizer.bypassSecurityTrustResourceUrl('assets/images/logo.svg')
     );
+    this.auth.addListener(this);
   }
 
   ngOnInit(): void {
     this.errorUnsuscriber = this.rest.errorEmitter.subscribe((e) =>
-      this.toastrService.show(e, 'Error', { duration: 5000 })
+      this.toastrService.show(e, 'Error', {duration: 5000})
     );
+  }
+
+  login(user: User): void {
     this.menu = [
       {
         title: 'Language Understanding',
         icon: 'message-circle-outline',
         link: '/nlp',
-        hidden: this.state.hasRole(UserRole.nlpUser)
+        hidden: !this.state.hasRole(UserRole.nlpUser)
       },
       {
         title: 'Model Quality',
         icon: 'clipboard-outline',
         link: '/quality',
-        hidden: this.state.hasRole(UserRole.nlpUser)
+        hidden: !this.state.hasRole(UserRole.nlpUser)
       },
       {
         title: 'Settings',
         icon: 'settings-outline',
         link: '/applications/nlu',
-        hidden: this.state.hasRole(UserRole.admin)
+        hidden: !this.state.hasRole(UserRole.admin)
       }
     ];
+  }
+
+  logout(): void {
   }
 
   ngOnDestroy(): void {

--- a/shared/src/main/kotlin/security/TockUserRole.kt
+++ b/shared/src/main/kotlin/security/TockUserRole.kt
@@ -27,6 +27,16 @@ enum class TockUserRole {
      * A nlp user is allowed to qualify and search sentences, but not to update applications or builds.
      */
     nlpUser,
+
+    /**
+     *  A faq nlp user is allowed to qualify and search sentences, and train the FAQ, but not to update applications or builds.
+     */
+    faqNlpUser,
+
+    /**
+     *  A faq bot user is allowed to qualify and search sentences, and train the FAQ, but not to update applications or builds.
+     */
+    faqBotUser,
     /**
      * A bot user is allowed to modify answer & i18n, and to consult dialogs and conversations.
      */

--- a/shared/src/main/kotlin/security/auth/PropertyBasedAuthProvider.kt
+++ b/shared/src/main/kotlin/security/auth/PropertyBasedAuthProvider.kt
@@ -16,12 +16,23 @@
 
 package ai.tock.shared.security.auth
 
-import ai.tock.shared.*
+import ai.tock.shared.Executor
+import ai.tock.shared.defaultNamespace
+import ai.tock.shared.injector
 import ai.tock.shared.jackson.mapper
+import ai.tock.shared.listProperty
+import ai.tock.shared.property
+import ai.tock.shared.provide
 import ai.tock.shared.security.TockUser
 import ai.tock.shared.security.TockUserListener
 import ai.tock.shared.security.TockUserRole
-import ai.tock.shared.security.TockUserRole.*
+import ai.tock.shared.security.TockUserRole.admin
+import ai.tock.shared.security.TockUserRole.botUser
+import ai.tock.shared.security.TockUserRole.faqBotUser
+import ai.tock.shared.security.TockUserRole.faqNlpUser
+import ai.tock.shared.security.TockUserRole.nlpUser
+import ai.tock.shared.security.TockUserRole.technicalAdmin
+import ai.tock.shared.security.TockUserRole.values
 import ai.tock.shared.vertx.WebVerticle
 import com.fasterxml.jackson.module.kotlin.readValue
 import io.vertx.core.AsyncResult
@@ -89,6 +100,8 @@ internal object PropertyBasedAuthProvider : TockAuthProvider {
                                         context.isAuthorized(admin) { adminResult ->
                                             context.isAuthorized(technicalAdmin) { technicalAdminResult ->
                                                 context.endJson(
+                                                    // if any of the role is detected for the user
+                                                    // add the role to the response
                                                     AuthenticateResponse(
                                                         true,
                                                         request.email,
@@ -144,7 +157,7 @@ internal object PropertyBasedAuthProvider : TockAuthProvider {
                             username,
                             organizations[index],
                             roles.getOrNull(index)
-                                ?.takeIf { r -> r.size > 1 || r.firstOrNull()?.isBlank() == false }
+                                ?.takeIf { role -> role.size > 1 || role.firstOrNull()?.isBlank() == false }
                                 ?: allRoles
                         ),
                         true

--- a/shared/src/main/kotlin/security/auth/PropertyBasedAuthProvider.kt
+++ b/shared/src/main/kotlin/security/auth/PropertyBasedAuthProvider.kt
@@ -16,22 +16,12 @@
 
 package ai.tock.shared.security.auth
 
-import ai.tock.shared.Executor
-import ai.tock.shared.defaultNamespace
-import ai.tock.shared.injector
+import ai.tock.shared.*
 import ai.tock.shared.jackson.mapper
-import ai.tock.shared.listProperty
-import ai.tock.shared.property
-import ai.tock.shared.provide
 import ai.tock.shared.security.TockUser
 import ai.tock.shared.security.TockUserListener
 import ai.tock.shared.security.TockUserRole
-import ai.tock.shared.security.TockUserRole.admin
-import ai.tock.shared.security.TockUserRole.botUser
-import ai.tock.shared.security.TockUserRole.nlpUser
-import ai.tock.shared.security.TockUserRole.technicalAdmin
-import ai.tock.shared.security.TockUserRole.values
-import ai.tock.shared.security.auth.PropertyBasedAuthProvider.authenticate
+import ai.tock.shared.security.TockUserRole.*
 import ai.tock.shared.vertx.WebVerticle
 import com.fasterxml.jackson.module.kotlin.readValue
 import io.vertx.core.AsyncResult
@@ -93,22 +83,28 @@ internal object PropertyBasedAuthProvider : TockAuthProvider {
                         val user = it.result()
                         context.setUser(user)
                         context.isAuthorized(nlpUser) { nlpUserResult ->
-                            context.isAuthorized(botUser) { botUserResult ->
-                                context.isAuthorized(admin) { adminResult ->
-                                    context.isAuthorized(technicalAdmin) { technicalAdminResult ->
-                                        context.endJson(
-                                            AuthenticateResponse(
-                                                true,
-                                                request.email,
-                                                (user as TockUser).namespace,
-                                                listOfNotNull(
-                                                    if (nlpUserResult.result()) nlpUser else null,
-                                                    if (botUserResult.result()) botUser else null,
-                                                    if (adminResult.result()) admin else null,
-                                                    if (technicalAdminResult.result()) technicalAdmin else null
+                            context.isAuthorized((faqNlpUser)) { faqNlpUserResult ->
+                                context.isAuthorized((faqBotUser)) { faqBotUserResult ->
+                                    context.isAuthorized(botUser) { botUserResult ->
+                                        context.isAuthorized(admin) { adminResult ->
+                                            context.isAuthorized(technicalAdmin) { technicalAdminResult ->
+                                                context.endJson(
+                                                    AuthenticateResponse(
+                                                        true,
+                                                        request.email,
+                                                        (user as TockUser).namespace,
+                                                        listOfNotNull(
+                                                            if (nlpUserResult.result()) nlpUser else null,
+                                                            if (faqNlpUserResult.result()) faqNlpUser else null,
+                                                            if (faqBotUserResult.result()) faqBotUser else null,
+                                                            if (botUserResult.result()) botUser else null,
+                                                            if (adminResult.result()) admin else null,
+                                                            if (technicalAdminResult.result()) technicalAdmin else null
+                                                        )
+                                                    )
                                                 )
-                                            )
-                                        )
+                                            }
+                                        }
                                     }
                                 }
                             }
@@ -147,7 +143,8 @@ internal object PropertyBasedAuthProvider : TockAuthProvider {
                         TockUser(
                             username,
                             organizations[index],
-                            roles.getOrNull(index)?.takeIf { r -> r.size > 1 || r.firstOrNull()?.isBlank() == false }
+                            roles.getOrNull(index)
+                                ?.takeIf { r -> r.size > 1 || r.firstOrNull()?.isBlank() == false }
                                 ?: allRoles
                         ),
                         true

--- a/shared/src/main/kotlin/vertx/WebVerticle.kt
+++ b/shared/src/main/kotlin/vertx/WebVerticle.kt
@@ -16,18 +16,36 @@
 
 package ai.tock.shared.vertx
 
-import ai.tock.shared.*
+import ai.tock.shared.booleanProperty
+import ai.tock.shared.devEnvironment
+import ai.tock.shared.error
+import ai.tock.shared.intProperty
 import ai.tock.shared.jackson.mapper
+import ai.tock.shared.longProperty
+import ai.tock.shared.property
 import ai.tock.shared.security.TockUser
 import ai.tock.shared.security.TockUserRole
-import ai.tock.shared.security.auth.*
+import ai.tock.shared.security.auth.AWSJWTAuthProvider
+import ai.tock.shared.security.auth.CASAuthProvider
+import ai.tock.shared.security.auth.GithubOAuthProvider
+import ai.tock.shared.security.auth.OAuth2Provider
+import ai.tock.shared.security.auth.PropertyBasedAuthProvider
+import ai.tock.shared.security.auth.TockAuthProvider
 import ai.tock.shared.security.auth.spi.CASAuthProviderFactory
 import com.fasterxml.jackson.core.JsonProcessingException
 import com.fasterxml.jackson.module.kotlin.MissingKotlinParameterException
 import com.fasterxml.jackson.module.kotlin.readValue
-import io.vertx.core.*
+import io.vertx.core.AbstractVerticle
+import io.vertx.core.AsyncResult
+import io.vertx.core.Future
+import io.vertx.core.Handler
+import io.vertx.core.Promise
+import io.vertx.core.Vertx
 import io.vertx.core.http.HttpMethod
-import io.vertx.core.http.HttpMethod.*
+import io.vertx.core.http.HttpMethod.DELETE
+import io.vertx.core.http.HttpMethod.GET
+import io.vertx.core.http.HttpMethod.POST
+import io.vertx.core.http.HttpMethod.PUT
 import io.vertx.core.http.HttpServer
 import io.vertx.core.http.HttpServerOptions
 import io.vertx.core.http.HttpServerResponse
@@ -47,7 +65,9 @@ import java.io.File
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.nio.file.Paths
-import java.util.*
+import java.util.EnumSet
+import java.util.Locale
+import java.util.ServiceLoader
 import kotlin.LazyThreadSafetyMode.PUBLICATION
 
 /**

--- a/shared/src/main/kotlin/vertx/WebVerticle.kt
+++ b/shared/src/main/kotlin/vertx/WebVerticle.kt
@@ -16,36 +16,18 @@
 
 package ai.tock.shared.vertx
 
-import ai.tock.shared.booleanProperty
-import ai.tock.shared.devEnvironment
-import ai.tock.shared.error
-import ai.tock.shared.intProperty
+import ai.tock.shared.*
 import ai.tock.shared.jackson.mapper
-import ai.tock.shared.longProperty
-import ai.tock.shared.property
 import ai.tock.shared.security.TockUser
 import ai.tock.shared.security.TockUserRole
-import ai.tock.shared.security.auth.AWSJWTAuthProvider
-import ai.tock.shared.security.auth.CASAuthProvider
-import ai.tock.shared.security.auth.GithubOAuthProvider
-import ai.tock.shared.security.auth.OAuth2Provider
-import ai.tock.shared.security.auth.PropertyBasedAuthProvider
-import ai.tock.shared.security.auth.TockAuthProvider
+import ai.tock.shared.security.auth.*
 import ai.tock.shared.security.auth.spi.CASAuthProviderFactory
 import com.fasterxml.jackson.core.JsonProcessingException
 import com.fasterxml.jackson.module.kotlin.MissingKotlinParameterException
 import com.fasterxml.jackson.module.kotlin.readValue
-import io.vertx.core.AbstractVerticle
-import io.vertx.core.AsyncResult
-import io.vertx.core.Future
-import io.vertx.core.Handler
-import io.vertx.core.Promise
-import io.vertx.core.Vertx
+import io.vertx.core.*
 import io.vertx.core.http.HttpMethod
-import io.vertx.core.http.HttpMethod.DELETE
-import io.vertx.core.http.HttpMethod.GET
-import io.vertx.core.http.HttpMethod.POST
-import io.vertx.core.http.HttpMethod.PUT
+import io.vertx.core.http.HttpMethod.*
 import io.vertx.core.http.HttpServer
 import io.vertx.core.http.HttpServerOptions
 import io.vertx.core.http.HttpServerResponse
@@ -57,18 +39,16 @@ import io.vertx.ext.web.handler.CorsHandler
 import io.vertx.ext.web.handler.ErrorHandler
 import io.vertx.ext.web.handler.SessionHandler
 import io.vertx.ext.web.sstore.LocalSessionStore
-import java.io.File
-import java.nio.charset.StandardCharsets
-import java.nio.file.Files
-import java.nio.file.Paths
-import java.util.EnumSet
-import java.util.Locale
-import java.util.ServiceLoader
-import kotlin.LazyThreadSafetyMode.PUBLICATION
 import mu.KLogger
 import mu.KotlinLogging
 import org.litote.kmongo.Id
 import org.litote.kmongo.toId
+import java.io.File
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Paths
+import java.util.*
+import kotlin.LazyThreadSafetyMode.PUBLICATION
 
 /**
  * Base class for web Tock [io.vertx.core.Verticle]s. Provides utility methods.
@@ -269,6 +249,7 @@ abstract class WebVerticle : AbstractVerticle() {
      * The default role of a service.
      */
     open fun defaultRole(): TockUserRole? = null
+
     /**
      * The default roles of a service.
      */
@@ -374,9 +355,9 @@ abstract class WebVerticle : AbstractVerticle() {
         val tockUser = user() as TockUser
         val tockUserRoles = tockUser.roles
         // if any of the role are in the profile then you can invoke the handler
-        if (roles.any { tockUserRole -> tockUserRole?.name in tockUser.roles}){
+        if (roles.any { tockUserRole -> tockUserRole?.name in tockUser.roles }) {
             val aRole = roles.first { it?.name in tockUserRoles }?.name
-                user()?.isAuthorized(aRole, resultHandler)
+            user()?.isAuthorized(aRole, resultHandler)
         } else {
             resultHandler.invoke(Future.failedFuture("Not authorized for user"))
         }
@@ -423,7 +404,7 @@ abstract class WebVerticle : AbstractVerticle() {
         role: TockUserRole,
         handler: (RoutingContext) -> O
     ) {
-        blockingJsonGet(path,setOf(role),handler)
+        blockingJsonGet(path, setOf(role), handler)
     }
 
     fun <O> blockingJsonGet(
@@ -443,7 +424,7 @@ abstract class WebVerticle : AbstractVerticle() {
         logger: RequestLogger = defaultRequestLogger,
         handler: (RoutingContext) -> Unit
     ) {
-        blockingPost(path,setOf(role),logger,handler)
+        blockingPost(path, setOf(role), logger, handler)
     }
 
     protected fun blockingPost(
@@ -483,7 +464,7 @@ abstract class WebVerticle : AbstractVerticle() {
         logger: RequestLogger = defaultRequestLogger,
         crossinline handler: (RoutingContext, F) -> O
     ) {
-        blockingUploadJsonPost(path, setOf(role),logger,handler)
+        blockingUploadJsonPost(path, setOf(role), logger, handler)
     }
 
     protected inline fun <reified F : Any, O> blockingUploadJsonPost(
@@ -515,7 +496,7 @@ abstract class WebVerticle : AbstractVerticle() {
         logger: RequestLogger = defaultRequestLogger,
         crossinline handler: (RoutingContext, String) -> O
     ) {
-        blockingUploadPost(path,setOf(role),logger,handler)
+        blockingUploadPost(path, setOf(role), logger, handler)
     }
 
     protected inline fun <O> blockingUploadPost(
@@ -545,7 +526,7 @@ abstract class WebVerticle : AbstractVerticle() {
         role: TockUserRole,
         crossinline handler: (RoutingContext, Pair<String, ByteArray>) -> O
     ) {
-        blockingUploadBinaryPost(path,setOf(role), handler)
+        blockingUploadBinaryPost(path, setOf(role), handler)
     }
 
     protected inline fun <O> blockingUploadBinaryPost(
@@ -602,7 +583,7 @@ abstract class WebVerticle : AbstractVerticle() {
         logger: RequestLogger = defaultRequestLogger,
         handler: (RoutingContext) -> Unit
     ) {
-        blockingDelete(path,role?.let { setOf(role) },logger,handler)
+        blockingDelete(path, role?.let { setOf(role) }, logger, handler)
     }
 
     fun blockingDelete(
@@ -631,7 +612,7 @@ abstract class WebVerticle : AbstractVerticle() {
         logger: RequestLogger = defaultRequestLogger,
         handler: (RoutingContext) -> Boolean
     ) {
-        blockingJsonDelete(path,setOf(role),logger,handler)
+        blockingJsonDelete(path, setOf(role), logger, handler)
     }
 
     protected fun blockingJsonDelete(


### PR DESCRIPTION
New Role management support :

In TockUserRole :
`faqNlpUser` 
`faqBotUser`

Some of the endpoints restrictions have changed , there are many shared endpoints for botUser and faqBotUser and also nlpUser and faqNlpUser.
The menu display are now working according to the role the user have.

faqNlpUser have acces to :
- Test
- FAQ Training

faqBotUser have access to :
- Test
- Analytics
- FAQ Training
- FAQ Management

Adding some endpoint restriction to admin Role on : 
`/bot`
`configuration/bot