### PR TITLE
:sparkles: use headers from react kit to push data into client bot ap…

### DIFF
--- a/bot/api/model/src/main/kotlin/RequestContext.kt
+++ b/bot/api/model/src/main/kotlin/RequestContext.kt
@@ -30,5 +30,6 @@ data class RequestContext(
     val applicationId: String,
     val userId: PlayerId,
     val botId: PlayerId,
-    val user: UserData
+    val user: UserData,
+    val metadata: MutableMap<String, String> = mutableMapOf()
 )

--- a/bot/api/model/src/main/kotlin/ResponseContext.kt
+++ b/bot/api/model/src/main/kotlin/ResponseContext.kt
@@ -19,4 +19,4 @@ package ai.tock.bot.api.model
 import java.time.Instant
 import java.time.Instant.now
 
-data class ResponseContext(val requestId: String, val date: Instant = now())
+data class ResponseContext(val requestId: String, val date: Instant = now(), val metadata: MutableMap<String, String> = mutableMapOf())

--- a/bot/connector-web/src/main/kotlin/WebConnector.kt
+++ b/bot/connector-web/src/main/kotlin/WebConnector.kt
@@ -88,7 +88,9 @@ private val cookieAuth = booleanProperty("tock_web_cookie_auth", false)
 
 private val webConnectorBridgeEnabled = booleanProperty("tock_web_connector_bridge_enabled", false)
 
-private val webConnectorExtraHeaders = listProperty("tock_web_connector_extra_headers", emptyList())
+val webConnectorExtraHeaders = listProperty("tock_web_connector_extra_headers", emptyList())
+val webConnectorUseExtraHeadersAsMetadata: Boolean =
+    booleanProperty("tock_web_connector_use_extra_header_as_metadata_request", false)
 
 class WebConnector internal constructor(
         val applicationId: String,
@@ -223,7 +225,8 @@ class WebConnector internal constructor(
                         applicationId
 
             val event = request.toEvent(applicationId)
-            WebRequestInfosByEvent.put(event.id.toString(), WebRequestInfos(context.request()))
+            val requestInfos = WebRequestInfos(context.request())
+            WebRequestInfosByEvent.put(event.id.toString(), requestInfos)
             val callback = WebConnectorCallback(
                     applicationId = applicationId,
                     locale = request.locale,
@@ -231,13 +234,36 @@ class WebConnector internal constructor(
                     webMapper = webMapper,
                     eventId = event.id.toString()
             )
-            controller.handle(event, ConnectorData(callback))
+            controller.handle(
+                event,
+                ConnectorData(
+                    callback = callback, metadata = extraHeadersAsMetadata(requestInfos)
+                )
+            )
         } catch (t: Throwable) {
             BotRepository.requestTimer.throwable(t, timerData)
             context.fail(t)
         } finally {
             BotRepository.requestTimer.end(timerData)
         }
+    }
+
+    /**
+     * add extra configured Header to Metadata
+     * accessible if "tock_web_connector_use_extra_header_as_metadata_request" is true
+     * @param requestInfos [WebRequestInfos]
+     */
+    private fun extraHeadersAsMetadata(requestInfos: WebRequestInfos): MutableMap<String, String> {
+        val metaDataExtraHeaders: MutableMap<String, String> = mutableMapOf()
+        if (webConnectorUseExtraHeadersAsMetadata) {
+            webConnectorExtraHeaders.forEach {
+                val headerSearch = requestInfos.headers(it)
+                if (headerSearch.isNotEmpty() && headerSearch.size == 1) {
+                    metaDataExtraHeaders.putIfAbsent(it, requestInfos.headers(it)[0])
+                }
+            }
+        }
+        return metaDataExtraHeaders
     }
 
     private fun handleProxy(

--- a/bot/engine/src/main/kotlin/connector/ConnectorData.kt
+++ b/bot/engine/src/main/kotlin/connector/ConnectorData.kt
@@ -43,7 +43,12 @@ open class ConnectorData(
     /**
      * An optional referer.
      */
-    val referer: String? = null
+    val referer: String? = null,
+
+    /**
+     * optional metadata metadata from connector
+     */
+    val metadata: MutableMap<String, String> = mutableMapOf()
 ) {
     /**
      * Set to true if the bot does not make any answer to a user sentence.


### PR DESCRIPTION
Adding the metadata to transfer information from headers allowed from the TockReactKit Web.
The metadata is transfered in ConnectorData (the field was already existing) to be available in the TockClientBus with `bus.request.context.metadata` in the botApplication created with Bot Api mode.