### PR TITLE
Feature/bot api/dercbot 396 397 409

### DIFF
--- a/bot/api/model/src/main/kotlin/RequestContext.kt
+++ b/bot/api/model/src/main/kotlin/RequestContext.kt
@@ -16,6 +16,7 @@
 
 package ai.tock.bot.api.model
 
+import ai.tock.bot.admin.dialog.ActionReport
 import ai.tock.bot.api.model.context.UserData
 import ai.tock.bot.connector.ConnectorType
 import ai.tock.bot.engine.user.PlayerId
@@ -30,5 +31,11 @@ data class RequestContext(
     val applicationId: String,
     val userId: PlayerId,
     val botId: PlayerId,
-    val user: UserData
+    val user: UserData,
+    val actionsHistory: ActionsHistory
 )
+
+/**
+ * The action history from the dialog [DialogReport] with [ActionReport]
+ */
+typealias ActionsHistory = List<ActionReport>

--- a/bot/api/model/src/main/kotlin/RequestContext.kt
+++ b/bot/api/model/src/main/kotlin/RequestContext.kt
@@ -32,6 +32,7 @@ data class RequestContext(
     val userId: PlayerId,
     val botId: PlayerId,
     val user: UserData,
+    val metadata: MutableMap<String, String> = mutableMapOf(),
     val actionsHistory: ActionsHistory
 )
 

--- a/bot/api/model/src/main/kotlin/RequestContext.kt
+++ b/bot/api/model/src/main/kotlin/RequestContext.kt
@@ -33,7 +33,7 @@ data class RequestContext(
     val botId: PlayerId,
     val user: UserData,
     val metadata: MutableMap<String, String> = mutableMapOf(),
-    val actionsHistory: ActionsHistory
+    val actionsHistory: ActionsHistory? = null
 )
 
 /**

--- a/bot/api/service/README.md
+++ b/bot/api/service/README.md
@@ -1,0 +1,10 @@
+# Tock-bot-api-service
+
+## Properties
+
+- `tock_bot_api_actions_history_to_client_bus` to true if you want to transfer action history in UserRequest context (payload is larger), default is false
+- `tock_api_timout_in_s` timeout in seconds for websocket service, default is 10
+- `tock_bot_api_timeout_in_ms` timeout in milliseconds for webhook service, default is 5000L
+
+
+

--- a/bot/api/service/src/main/kotlin/Transformers.kt
+++ b/bot/api/service/src/main/kotlin/Transformers.kt
@@ -16,6 +16,8 @@
 
 package ai.tock.bot.api.service
 
+import ai.tock.bot.admin.dialog.ActionReport
+import ai.tock.bot.api.model.ActionsHistory
 import ai.tock.bot.api.model.RequestContext
 import ai.tock.bot.api.model.UserRequest
 import ai.tock.bot.api.model.context.Entity
@@ -70,8 +72,26 @@ private fun BotBus.toRequestContext(): RequestContext =
         applicationId,
         userId,
         botId,
-        userPreferences.toUserData()
+        userPreferences.toUserData(),
+        toActionsHistory(),
     )
+
+/**
+ * Retrieve the action history from the dialog
+ */
+private fun BotBus.toActionsHistory(): ActionsHistory =
+    dialog.allActions().toList().map {
+        ActionReport(
+            it.playerId,
+            it.recipientId,
+            it.date,
+            it.toMessage(),
+            targetConnectorType,
+            userInterfaceType,
+            test,
+            it.toActionId()
+        )
+    }
 
 private fun UserPreferences.toUserData(): UserData =
     UserData(

--- a/bot/api/service/src/main/kotlin/Transformers.kt
+++ b/bot/api/service/src/main/kotlin/Transformers.kt
@@ -31,6 +31,7 @@ import ai.tock.bot.engine.action.SendChoice
 import ai.tock.bot.engine.action.SendSentence
 import ai.tock.bot.engine.dialog.EntityValue
 import ai.tock.bot.engine.user.UserPreferences
+import ai.tock.shared.booleanProperty
 
 internal fun BotBus.toUserRequest(): UserRequest =
     UserRequest(
@@ -73,7 +74,8 @@ private fun BotBus.toRequestContext(): RequestContext =
         userId,
         botId,
         userPreferences.toUserData(),
-        toActionsHistory(),
+        connectorData.metadata,
+        if (booleanProperty("tock_bot_api_actions_history_to_client_bus", false)) toActionsHistory() else null,
     )
 
 /**

--- a/bot/api/service/src/test/kotlin/BotApiHandlerTest.kt
+++ b/bot/api/service/src/test/kotlin/BotApiHandlerTest.kt
@@ -17,18 +17,21 @@
 import ai.tock.bot.admin.bot.BotConfiguration
 import ai.tock.bot.admin.story.StoryDefinitionConfigurationDAO
 import ai.tock.bot.api.model.BotResponse
+import ai.tock.bot.api.model.UserRequest
 import ai.tock.bot.api.model.message.bot.I18nText
 import ai.tock.bot.api.model.message.bot.Sentence
 import ai.tock.bot.api.model.websocket.ResponseData
 import ai.tock.bot.api.service.BotApiClientController
 import ai.tock.bot.api.service.BotApiDefinitionProvider
 import ai.tock.bot.api.service.BotApiHandler
+import ai.tock.bot.api.service.toUserRequest
 import ai.tock.bot.definition.StoryDefinition
 import ai.tock.bot.engine.BotBus
 import ai.tock.bot.engine.action.SendSentence
 import ai.tock.bot.engine.dialog.Dialog
 import ai.tock.bot.engine.dialog.DialogState
 import ai.tock.bot.engine.dialog.NextUserActionState
+import ai.tock.bot.engine.user.PlayerId
 import ai.tock.nlp.api.client.model.NlpIntentQualifier
 import ai.tock.shared.tockInternalInjector
 import com.github.salomonbrys.kodein.Kodein
@@ -37,13 +40,20 @@ import com.github.salomonbrys.kodein.bind
 import com.github.salomonbrys.kodein.provider
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.slot
 import io.mockk.verify
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 
-class   BotApiHandlerTest {
+class BotApiHandlerTest {
+
+    companion object {
+        private const val TOCK_ACTIONS_HISTORY_ENABLE_PROPERTY = "tock_bot_api_actions_history_to_client_bus"
+    }
 
     private val provider: BotApiDefinitionProvider = mockk()
     private val configuration: BotConfiguration = mockk {
@@ -56,10 +66,13 @@ class   BotApiHandlerTest {
             every { stringText } returns "user text"
             every { getBusContextValue<Set<StoryDefinition>>("_viewed_stories_tock_switch") } returns emptySet()
         }
-        every { dialog } returns mockk<Dialog>{
+        every { dialog } returns mockk<Dialog> {
             every { state } returns mockk<DialogState> {
-                every{ nextActionState } returns mockk<NextUserActionState>{
-                    every {intentsQualifiers} returns listOf(NlpIntentQualifier("intent1",0.5), NlpIntentQualifier("intent2",0.5))
+                every { nextActionState } returns mockk<NextUserActionState> {
+                    every { intentsQualifiers } returns listOf(
+                        NlpIntentQualifier("intent1", 0.5),
+                        NlpIntentQualifier("intent2", 0.5)
+                    )
                 }
             }
         }
@@ -105,6 +118,15 @@ class   BotApiHandlerTest {
         )
     }
 
+    @AfterEach
+    fun cleanup() {
+        clearProperties()
+    }
+
+    private fun clearProperties() {
+        System.clearProperty(TOCK_ACTIONS_HISTORY_ENABLE_PROPERTY)
+    }
+
     @Test
     fun `Configured ending story is taken into account`() {
         val handler = BotApiHandler(provider, configuration, clientController)
@@ -121,6 +143,89 @@ class   BotApiHandlerTest {
 
         handler.send(bus)
 
-        assertEquals(bus.dialog.state.nextActionState?.intentsQualifiers, listOf(NlpIntentQualifier("intent1",0.5), NlpIntentQualifier("intent2",0.5)))
+        assertEquals(
+            bus.dialog.state.nextActionState?.intentsQualifiers,
+            listOf(NlpIntentQualifier("intent1", 0.5), NlpIntentQualifier("intent2", 0.5))
+        )
     }
+
+    @Test
+    fun `actions history present in bus with actions`() {
+        System.setProperty(
+            TOCK_ACTIONS_HISTORY_ENABLE_PROPERTY, "true")
+
+        val mockedBus: BotBus = bus.apply {
+            every { bus.dialog } returns mockk {
+                every { getBusContextValue<Set<StoryDefinition>>("_viewed_stories_tock_switch") } returns emptySet()
+                every { dialog.allActions() } returns listOf(
+                    SendSentence(PlayerId("user"), "appId", PlayerId("bot"), "user Sentence"),
+                    SendSentence(PlayerId("bot"), "appId", PlayerId("user"), "bot Sentence")
+                )
+            }
+        }
+
+        val handler = BotApiHandler(provider, configuration, clientController)
+
+        handler.send(mockedBus)
+
+        val slot = slot<UserRequest>()
+        verify { clientController.send(capture(slot)) }
+
+        assertEquals(mockedBus.toUserRequest().context.actionsHistory, slot.captured.context.actionsHistory)
+        assertEquals(mockedBus.toUserRequest().context.actionsHistory?.size, 2)
+        assertTrue(mockedBus.toUserRequest().context.actionsHistory != null)
+    }
+
+    @Test
+    fun `actions history property not set and no actions history in bus`() {
+        System.setProperty(
+            TOCK_ACTIONS_HISTORY_ENABLE_PROPERTY, "false")
+
+        val mockedBus: BotBus = bus.apply {
+            every { bus.dialog } returns mockk {
+                every { getBusContextValue<Set<StoryDefinition>>("_viewed_stories_tock_switch") } returns emptySet()
+                every { dialog.allActions() } returns listOf(
+                    SendSentence(PlayerId("user"), "appId", PlayerId("bot"), "user Sentence"),
+                    SendSentence(PlayerId("bot"), "appId", PlayerId("user"), "bot Sentence")
+                )
+            }
+        }
+
+        val handler = BotApiHandler(provider, configuration, clientController)
+
+        handler.send(mockedBus)
+
+        val slot = slot<UserRequest>()
+        verify { clientController.send(capture(slot)) }
+
+        assertEquals(null, slot.captured.context.actionsHistory)
+        assertEquals(mockedBus.toUserRequest().context.actionsHistory?.size, null)
+        assertTrue(mockedBus.toUserRequest().context.actionsHistory == null)
+    }
+
+    @Test
+    fun `actions history property set and no actions history in bus`() {
+        System.setProperty(
+            TOCK_ACTIONS_HISTORY_ENABLE_PROPERTY, "true")
+
+        val mockedBus: BotBus = bus.apply {
+            every { bus.dialog } returns mockk {
+                every { getBusContextValue<Set<StoryDefinition>>("_viewed_stories_tock_switch") } returns emptySet()
+                every { dialog.allActions() } returns emptyList()
+            }
+        }
+
+        val handler = BotApiHandler(provider, configuration, clientController)
+
+        handler.send(mockedBus)
+
+        val slot = slot<UserRequest>()
+        verify { clientController.send(capture(slot)) }
+
+        assertEquals(emptyList(), slot.captured.context.actionsHistory)
+        assertEquals( 0,mockedBus.toUserRequest().context.actionsHistory?.size,)
+        assertTrue(mockedBus.toUserRequest().context.actionsHistory != null)
+    }
+
+
 }

--- a/bot/connector-web/README.md
+++ b/bot/connector-web/README.md
@@ -176,6 +176,8 @@ The HTTP parameters, allowed by default can be found in [`WebConnector`](./src/m
 To allow extra parameters without modifying the Web connector, use the optional `tock_web_connector_extra_headers` 
 property.
 
+To retrieve metadata present in headers and use retrieve them in `Bus` in the `ConnectorData`, use the `tock_web_connector_use_extra_header_as_metadata_request` and pass it to true.
+
 Docker-Compose example:
 
 ```

--- a/bot/connector-web/README.md
+++ b/bot/connector-web/README.md
@@ -176,7 +176,7 @@ The HTTP parameters, allowed by default can be found in [`WebConnector`](./src/m
 To allow extra parameters without modifying the Web connector, use the optional `tock_web_connector_extra_headers` 
 property.
 
-To retrieve metadata present in headers and use retrieve them in `Bus` in the `ConnectorData`, use the `tock_web_connector_use_extra_header_as_metadata_request` and pass it to true.
+To retrieve metadata present in extra headers (the list present in `tock_web_connector_extra_headers`) and use them in `Bus` in the `ConnectorData`, use the `tock_web_connector_use_extra_header_as_metadata_request` and pass it to true.
 
 Docker-Compose example:
 

--- a/bot/connector-web/src/main/kotlin/WebConnector.kt
+++ b/bot/connector-web/src/main/kotlin/WebConnector.kt
@@ -88,7 +88,9 @@ private val cookieAuth = booleanProperty("tock_web_cookie_auth", false)
 
 private val webConnectorBridgeEnabled = booleanProperty("tock_web_connector_bridge_enabled", false)
 
-private val webConnectorExtraHeaders = listProperty("tock_web_connector_extra_headers", emptyList())
+val webConnectorExtraHeaders = listProperty("tock_web_connector_extra_headers", emptyList())
+val webConnectorUseExtraHeadersAsMetadata: Boolean =
+    booleanProperty("tock_web_connector_use_extra_header_as_metadata_request", false)
 
 class WebConnector internal constructor(
         val applicationId: String,
@@ -223,7 +225,8 @@ class WebConnector internal constructor(
                         applicationId
 
             val event = request.toEvent(applicationId)
-            WebRequestInfosByEvent.put(event.id.toString(), WebRequestInfos(context.request()))
+            val requestInfos = WebRequestInfos(context.request())
+            WebRequestInfosByEvent.put(event.id.toString(), requestInfos)
             val callback = WebConnectorCallback(
                     applicationId = applicationId,
                     locale = request.locale,
@@ -231,13 +234,36 @@ class WebConnector internal constructor(
                     webMapper = webMapper,
                     eventId = event.id.toString()
             )
-            controller.handle(event, ConnectorData(callback))
+            controller.handle(
+                event,
+                ConnectorData(
+                    callback = callback, metadata = extraHeadersAsMetadata(requestInfos)
+                )
+            )
         } catch (t: Throwable) {
             BotRepository.requestTimer.throwable(t, timerData)
             context.fail(t)
         } finally {
             BotRepository.requestTimer.end(timerData)
         }
+    }
+
+    /**
+     * add extra configured Header to Metadata
+     * accessible if "tock_web_connector_use_extra_header_as_metadata_request" is true
+     * @param requestInfos [WebRequestInfos]
+     */
+    private fun extraHeadersAsMetadata(requestInfos: WebRequestInfos): MutableMap<String, String> {
+        val metaDataExtraHeaders: MutableMap<String, String> = mutableMapOf()
+        if (webConnectorUseExtraHeadersAsMetadata) {
+            webConnectorExtraHeaders.forEach {
+                val headerSearch = requestInfos.headers(it)
+                if (headerSearch.isNotEmpty()) {
+                    metaDataExtraHeaders.putIfAbsent(it, headerSearch[0])
+                }
+            }
+        }
+        return metaDataExtraHeaders
     }
 
     private fun handleProxy(

--- a/bot/connector-web/src/main/kotlin/WebConnector.kt
+++ b/bot/connector-web/src/main/kotlin/WebConnector.kt
@@ -256,10 +256,9 @@ class WebConnector internal constructor(
     private fun extraHeadersAsMetadata(requestInfos: WebRequestInfos): MutableMap<String, String> {
         val metaDataExtraHeaders: MutableMap<String, String> = mutableMapOf()
         if (webConnectorUseExtraHeadersAsMetadata) {
-            webConnectorExtraHeaders.forEach {
-                val headerSearch = requestInfos.headers(it)
-                if (headerSearch.isNotEmpty()) {
-                    metaDataExtraHeaders.putIfAbsent(it, headerSearch[0])
+            webConnectorExtraHeaders.forEach { header ->
+                requestInfos.firstHeader(header)?.let {
+                    metaDataExtraHeaders.putIfAbsent(header, it)
                 }
             }
         }

--- a/bot/engine/src/main/kotlin/connector/ConnectorData.kt
+++ b/bot/engine/src/main/kotlin/connector/ConnectorData.kt
@@ -43,7 +43,12 @@ open class ConnectorData(
     /**
      * An optional referer.
      */
-    val referer: String? = null
+    val referer: String? = null,
+
+    /**
+     * optional metadata metadata from connector
+     */
+    val metadata: MutableMap<String, String> = mutableMapOf()
 ) {
     /**
      * Set to true if the bot does not make any answer to a user sentence.


### PR DESCRIPTION
TODO ; A merger sur une branche adéquate qui servira de livraison. (merge des deux features concernant l'ajout de données complémentaire accessibles depuis le ClientBus du BotApi)

Explication du travail réalisé avec l'ajout d'informations transmises avec les actions et pour les metadatas avec le header.

![drawio-BOTBUS to ClientBus drawio](https://user-images.githubusercontent.com/22080627/215126403-3ca3fdad-2d40-4e74-8565-04906cba40ee.png)

Création d'un README sur le module `tock-bot-api-service` et explication des variables d'environnement.
Ajout d'une propriété supplémentaire dans le README.md 

Propriétés : 
- pour gérer l'ajout des actions dans les requêtes : tock_bot_api_actions_history_to_client_bus à true
- pour ajouter les metadatas présents dans les headers :  tock_web_connector_use_extra_header_as_metadata_request à true
