### PR TITLE
sentence-edit carriage return fix

### DIFF
--- a/bot/admin/web/src/app/scenarios/scenario-designer/scenario-conception/intent-edit/sentence/sentence-edit.component.html
+++ b/bot/admin/web/src/app/scenarios/scenario-designer/scenario-conception/intent-edit/sentence/sentence-edit.component.html
@@ -6,14 +6,13 @@
   [style.color]="getContrastYIQ(token.color())"
   [nbTooltip]="getTokenTooltip(token)"
   (click)="displayTokenMenu($event, token)"
->
-  {{ token.text }}
-  <nb-icon
+  ><!-- NO carriage return here ! -->{{ token.text
+  }}<nb-icon
     icon="code-download-outline"
     class="valign-middle ml-1"
     *ngIf="getContextOfEntity(token)"
-  ></nb-icon>
-</span>
+  ></nb-icon
+></span>
 
 <div
   *ngIf="txtSelection"


### PR DESCRIPTION
Scenario-designer : Fix a carriage return added between two tags that shifts an index count for selecting the portion of text to add an entity to.