### PR TITLE
[DERCBOT-441] Internalization of parameterized iAdvize messages

### DIFF
--- a/bot/connector-iadvize/src/main/kotlin/IadvizeBuilder.kt
+++ b/bot/connector-iadvize/src/main/kotlin/IadvizeBuilder.kt
@@ -19,7 +19,7 @@ package ai.tock.bot.connector.iadvize
 
 import ai.tock.bot.connector.ConnectorType
 import ai.tock.bot.connector.iadvize.model.response.conversation.QuickReply
-import ai.tock.bot.connector.iadvize.model.response.conversation.payload.TextPayload
+import ai.tock.bot.connector.iadvize.model.payload.TextPayload
 import ai.tock.bot.connector.iadvize.model.response.conversation.Duration
 import ai.tock.bot.connector.iadvize.model.response.conversation.reply.IadvizeMessage
 import ai.tock.bot.connector.iadvize.model.response.conversation.reply.IadvizeMultipartReply

--- a/bot/connector-iadvize/src/main/kotlin/IadvizeConnectorMessage.kt
+++ b/bot/connector-iadvize/src/main/kotlin/IadvizeConnectorMessage.kt
@@ -18,7 +18,7 @@ package ai.tock.bot.connector.iadvize
 
 import ai.tock.bot.connector.ConnectorMessage
 import ai.tock.bot.connector.ConnectorType
-import ai.tock.bot.connector.iadvize.model.response.conversation.payload.TextPayload
+import ai.tock.bot.connector.iadvize.model.payload.TextPayload
 import ai.tock.bot.connector.iadvize.model.response.conversation.reply.IadvizeMessage
 import ai.tock.bot.connector.iadvize.model.response.conversation.reply.IadvizeMultipartReply
 import ai.tock.bot.connector.iadvize.model.response.conversation.reply.IadvizeReply
@@ -49,7 +49,7 @@ data class IadvizeConnectorMessage(val replies: List<IadvizeReply>) : ConnectorM
             .map { message ->
                 GenericMessage(
                     connectorType = connectorType,
-                    texts = mapOf("text" to (message.payload as TextPayload).value),
+                    texts = mapOf("text" to (message.payload as TextPayload).value.toString()),
                     choices = message.quickReplies.map { Choice.fromText(it.value) }
                 )
             }

--- a/bot/connector-iadvize/src/main/kotlin/IadvizeConnectorProvider.kt
+++ b/bot/connector-iadvize/src/main/kotlin/IadvizeConnectorProvider.kt
@@ -34,7 +34,8 @@ internal object IadvizeConnectorProvider : ConnectorProvider {
     private const val FIRST_MESSAGE = "tock_iadvize_first_message"
     private const val DISTRIBUTION_RULE = "tock_iadvize_distribution_rule"
     private const val SECRET_TOKEN = "tock_iadvize_secret_token"
-    private const val DISTRIBUTION_RULE_UNVAILABLE_MESSAGE = "tock_iadvize_distribution_rule_unavailable"
+    private const val DISTRIBUTION_RULE_UNAVAILABLE_MESSAGE = "tock_iadvize_distribution_rule_unavailable"
+    private const val LOCALE_CODE = "tock_iadvize_locale_code"
 
     override fun connector(connectorConfiguration: ConnectorConfiguration): Connector {
         with(connectorConfiguration) {
@@ -45,7 +46,8 @@ internal object IadvizeConnectorProvider : ConnectorProvider {
                 parameters.getValue(FIRST_MESSAGE),
                 parameters.getOrDefault(DISTRIBUTION_RULE, null),
                 parameters.getOrDefault(SECRET_TOKEN, null),
-                parameters.getValue(DISTRIBUTION_RULE_UNVAILABLE_MESSAGE)
+                parameters.getValue(DISTRIBUTION_RULE_UNAVAILABLE_MESSAGE),
+                parameters.getOrDefault(LOCALE_CODE, null)
             )
         }
     }
@@ -73,13 +75,25 @@ internal object IadvizeConnectorProvider : ConnectorProvider {
             false
         )
         val distributionRuleUnvailableMessageField = ConnectorTypeConfigurationField(
-            properties.getProperty(DISTRIBUTION_RULE_UNVAILABLE_MESSAGE),
-            DISTRIBUTION_RULE_UNVAILABLE_MESSAGE,
+            properties.getProperty(DISTRIBUTION_RULE_UNAVAILABLE_MESSAGE),
+            DISTRIBUTION_RULE_UNAVAILABLE_MESSAGE,
             true
         )
+        val localeCode = ConnectorTypeConfigurationField(
+            properties.getProperty(LOCALE_CODE),
+            LOCALE_CODE,
+            false
+        )
+
         return ConnectorTypeConfiguration(
             connectorType,
-            listOf(editorUrlField, firstMessageField, distributionRuleField, secretToken, distributionRuleUnvailableMessageField),
+            listOf(editorUrlField,
+                firstMessageField,
+                distributionRuleField,
+                secretToken,
+                distributionRuleUnvailableMessageField,
+                localeCode
+            ),
             resourceAsString("/iadvize.svg")
         )
     }

--- a/bot/connector-iadvize/src/main/kotlin/MediaConverter.kt
+++ b/bot/connector-iadvize/src/main/kotlin/MediaConverter.kt
@@ -17,9 +17,9 @@ package ai.tock.bot.connector.iadvize
 
 import ai.tock.bot.connector.ConnectorMessage
 import ai.tock.bot.connector.iadvize.model.response.conversation.QuickReply
-import ai.tock.bot.connector.iadvize.model.response.conversation.payload.GenericCardPayload
-import ai.tock.bot.connector.iadvize.model.response.conversation.payload.Payload
-import ai.tock.bot.connector.iadvize.model.response.conversation.payload.TextPayload
+import ai.tock.bot.connector.iadvize.model.payload.GenericCardPayload
+import ai.tock.bot.connector.iadvize.model.payload.Payload
+import ai.tock.bot.connector.iadvize.model.payload.TextPayload
 import ai.tock.bot.connector.iadvize.model.response.conversation.payload.genericjson.Action
 import ai.tock.bot.connector.iadvize.model.response.conversation.payload.genericjson.Image
 import ai.tock.bot.connector.iadvize.model.response.conversation.reply.IadvizeMessage

--- a/bot/connector-iadvize/src/main/kotlin/model/payload/CardBundlePayload.kt
+++ b/bot/connector-iadvize/src/main/kotlin/model/payload/CardBundlePayload.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package ai.tock.bot.connector.iadvize.model.response.conversation.payload
+package ai.tock.bot.connector.iadvize.model.payload
 
 data class CardBundlePayload(val cards: MutableList<GenericCardPayload> = mutableListOf())
     : Payload("bundle/card")

--- a/bot/connector-iadvize/src/main/kotlin/model/payload/FilePayload.kt
+++ b/bot/connector-iadvize/src/main/kotlin/model/payload/FilePayload.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package ai.tock.bot.connector.iadvize.model.response.conversation.payload
+package ai.tock.bot.connector.iadvize.model.payload
 
 import com.fasterxml.jackson.annotation.JsonValue
 

--- a/bot/connector-iadvize/src/main/kotlin/model/payload/GenericCardPayload.kt
+++ b/bot/connector-iadvize/src/main/kotlin/model/payload/GenericCardPayload.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package ai.tock.bot.connector.iadvize.model.response.conversation.payload
+package ai.tock.bot.connector.iadvize.model.payload
 
 import ai.tock.bot.connector.iadvize.model.response.conversation.payload.genericjson.Image
 import ai.tock.bot.connector.iadvize.model.response.conversation.payload.genericjson.Action

--- a/bot/connector-iadvize/src/main/kotlin/model/payload/Payload.kt
+++ b/bot/connector-iadvize/src/main/kotlin/model/payload/Payload.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package ai.tock.bot.connector.iadvize.model.response.conversation.payload
+package ai.tock.bot.connector.iadvize.model.payload
 
 import com.fasterxml.jackson.annotation.JsonSubTypes
 import com.fasterxml.jackson.annotation.JsonTypeInfo

--- a/bot/connector-iadvize/src/main/kotlin/model/payload/ProductOfferBundlePayload.kt
+++ b/bot/connector-iadvize/src/main/kotlin/model/payload/ProductOfferBundlePayload.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package ai.tock.bot.connector.iadvize.model.response.conversation.payload
+package ai.tock.bot.connector.iadvize.model.payload
 
 data class ProductOfferBundlePayload(val cards: MutableList<ProductOfferPayload> = mutableListOf())
     : Payload("bundle/product-offer")

--- a/bot/connector-iadvize/src/main/kotlin/model/payload/ProductOfferPayload.kt
+++ b/bot/connector-iadvize/src/main/kotlin/model/payload/ProductOfferPayload.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package ai.tock.bot.connector.iadvize.model.response.conversation.payload
+package ai.tock.bot.connector.iadvize.model.payload
 
 import ai.tock.bot.connector.iadvize.model.response.conversation.payload.genericjson.Action
 import ai.tock.bot.connector.iadvize.model.response.conversation.payload.genericjson.Image

--- a/bot/connector-iadvize/src/main/kotlin/model/payload/TextPayload.kt
+++ b/bot/connector-iadvize/src/main/kotlin/model/payload/TextPayload.kt
@@ -14,6 +14,6 @@
  * limitations under the License.
  */
 
-package ai.tock.bot.connector.iadvize.model.response.conversation.payload
+package ai.tock.bot.connector.iadvize.model.payload
 
-data class TextPayload(val value: String) : Payload("text")
+data class TextPayload(val value: CharSequence) : Payload("text")

--- a/bot/connector-iadvize/src/main/kotlin/model/request/Message.kt
+++ b/bot/connector-iadvize/src/main/kotlin/model/request/Message.kt
@@ -16,7 +16,7 @@
 
 package ai.tock.bot.connector.iadvize.model.request
 
-import ai.tock.bot.connector.iadvize.model.response.conversation.payload.Payload
+import ai.tock.bot.connector.iadvize.model.payload.Payload
 
 data class Message<T : Payload>(
     val idMessage: String,

--- a/bot/connector-iadvize/src/main/kotlin/model/request/MessageRequest.kt
+++ b/bot/connector-iadvize/src/main/kotlin/model/request/MessageRequest.kt
@@ -16,7 +16,7 @@
 
 package ai.tock.bot.connector.iadvize.model.request
 
-import ai.tock.bot.connector.iadvize.model.response.conversation.payload.TextPayload
+import ai.tock.bot.connector.iadvize.model.payload.TextPayload
 
 data class MessageRequest(override val idOperator: String, override val idConversation: String, val message: Message<TextPayload>) : IadvizeRequest {
     data class MessageRequestJson(val idOperator: String, val message: Message<TextPayload>)

--- a/bot/connector-iadvize/src/main/kotlin/model/response/conversation/reply/IadvizeMessage.kt
+++ b/bot/connector-iadvize/src/main/kotlin/model/response/conversation/reply/IadvizeMessage.kt
@@ -17,8 +17,8 @@
 package ai.tock.bot.connector.iadvize.model.response.conversation.reply
 
 import ai.tock.bot.connector.iadvize.model.response.conversation.QuickReply
-import ai.tock.bot.connector.iadvize.model.response.conversation.payload.Payload
-import ai.tock.bot.connector.iadvize.model.response.conversation.payload.TextPayload
+import ai.tock.bot.connector.iadvize.model.payload.Payload
+import ai.tock.bot.connector.iadvize.model.payload.TextPayload
 
 data class IadvizeMessage(val payload: Payload,
                           val quickReplies: MutableList<QuickReply> = mutableListOf()) : IadvizeReply(ReplyType.message) {

--- a/bot/connector-iadvize/src/main/resources/iadvize.properties
+++ b/bot/connector-iadvize/src/main/resources/iadvize.properties
@@ -20,4 +20,5 @@ tock_iadvize_first_message= Conversation first message
 tock_iadvize_distribution_rule=Human transfer rule
 tock_iadvize_secret_token=IAdvize secret token
 tock_iadvize_distribution_rule_unavailable=Distribution rule unavailable message
+tock_iadvize_locale_code=Default locale (en, fr, ...)
 iadvize_graphql_url=https://api.iadvize.com/graphql

--- a/bot/connector-iadvize/src/test/kotlin/IadvizeConnectorMessageTest.kt
+++ b/bot/connector-iadvize/src/test/kotlin/IadvizeConnectorMessageTest.kt
@@ -14,14 +14,10 @@ package ai.tock.bot.connector.iadvize/*
  * limitations under the License.
  */
 
-import ai.tock.bot.connector.iadvize.IadvizeConnectorMessage
-import ai.tock.bot.connector.iadvize.iadvizeConnectorType
 import ai.tock.bot.connector.iadvize.model.response.conversation.Duration
 import ai.tock.bot.connector.iadvize.model.response.conversation.QuickReply
-import ai.tock.bot.connector.iadvize.model.response.conversation.payload.TextPayload
+import ai.tock.bot.connector.iadvize.model.payload.TextPayload
 import ai.tock.bot.connector.iadvize.model.response.conversation.reply.*
-import ai.tock.bot.connector.iadvize.minutes
-import ai.tock.bot.connector.iadvize.seconds
 import ai.tock.bot.engine.message.Choice
 import ai.tock.bot.engine.message.GenericMessage
 import org.junit.jupiter.api.Test

--- a/bot/connector-iadvize/src/test/kotlin/IadvizeConnectorTest.kt
+++ b/bot/connector-iadvize/src/test/kotlin/IadvizeConnectorTest.kt
@@ -21,7 +21,7 @@ import ai.tock.bot.connector.iadvize.model.request.MessageRequest
 import ai.tock.bot.connector.iadvize.model.request.MessageRequest.MessageRequestJson
 import ai.tock.bot.connector.iadvize.model.response.conversation.Duration
 import ai.tock.bot.connector.iadvize.model.response.conversation.QuickReply
-import ai.tock.bot.connector.iadvize.model.response.conversation.payload.TextPayload
+import ai.tock.bot.connector.iadvize.model.payload.TextPayload
 import ai.tock.bot.connector.iadvize.model.response.conversation.reply.*
 import ai.tock.bot.engine.ConnectorController
 import ai.tock.bot.engine.I18nTranslator
@@ -55,7 +55,7 @@ class IadvizeConnectorTest {
     val firstMessage = "firstMessage"
     val distributionRule = "distributionRuleId"
     val distributionRuleUnavailableMessage = "distributionRuleUnavailableMessage"
-    val connector = IadvizeConnector(applicationId, path, editorURL,firstMessage, distributionRule, null, distributionRuleUnavailableMessage)
+    val connector = IadvizeConnector(applicationId, path, editorURL,firstMessage, distributionRule, null, distributionRuleUnavailableMessage, null)
     val controller: ConnectorController = mockk(relaxed = true)
     val context: RoutingContext = mockk(relaxed = true)
     val response: HttpServerResponse = mockk(relaxed = true)
@@ -66,6 +66,7 @@ class IadvizeConnectorTest {
     val conversationId = "conversationId"
 
 
+    private val marcus: String = "MARCUS"
     private val marcus1: String = "MARCUS1"
     private val marcus2: String = "MARCUS2"
 
@@ -80,15 +81,15 @@ class IadvizeConnectorTest {
         every { context.pathParam("idConversation") } returns conversationId
 
         every { controller.botDefinition.i18nTranslator(any(), any(), any(), any()) } returns translator
-        val marcusAnswer1 = I18nLabelValue("", "", "", marcus1)
-        every { translator.translate(marcus1) } returns marcusAnswer1.raw
-        val marcusAnswer2 = I18nLabelValue("", "", "", marcus2)
-        every { translator.translate(marcus2) } returns marcusAnswer2.raw
+
+        val messageSlot = slot<CharSequence>()
+        every { translator.translate(capture(messageSlot)) } answers { I18nLabelValue("", "", "", messageSlot.captured).raw }
 
         // Force date to expected date
         mockkStatic(LocalDateTime::class)
         every { LocalDateTime.now() } returns LocalDateTime.of(2022, 4, 8, 16, 52, 37)
         every { LocalDateTime.of(2022, 4, 8, 16, 52, 37) } answers { callOriginal() }
+
     }
 
     @Test


### PR DESCRIPTION
   - Fixed package name
   - Add a new parameter (locale) to the connector
   - Translate messages to display and administer them as answers in the tock studio