### PR TITLE
[DERCBOT-471] Fix unit tests

### DIFF
--- a/.idea/runConfigurations/BotAdmin.xml
+++ b/.idea/runConfigurations/BotAdmin.xml
@@ -3,6 +3,8 @@
     <envs>
       <env name="botadminverticle_port" value="7999" />
       <env name="botadminverticle_body_limit" value="-1" />
+      <!-- TODO MASS : to be deleted with DERCBOT-321 -->
+      <env name="tock_bot_dialog_manager_debug_enabled" value="true" />
     </envs>
     <option name="MAIN_CLASS_NAME" value="ai.tock.bot.admin.StartBotAdminServerKt" />
     <module name="tock-bot-admin-server" />

--- a/.idea/runConfigurations/BotApi.xml
+++ b/.idea/runConfigurations/BotApi.xml
@@ -2,6 +2,8 @@
   <configuration default="false" name="BotApi" type="JetRunConfigurationType">
     <envs>
       <env name="tock_websocket_enabled" value="true" />
+      <!-- TODO MASS : to be deleted with DERCBOT-321 -->
+      <env name="tock_bot_dialog_manager_debug_enabled" value="true" />
     </envs>
     <option name="MAIN_CLASS_NAME" value="ai.tock.bot.api.service.StartBotApiKt" />
     <module name="tock-bot-api-service" />

--- a/bot/admin/test/core/src/main/kotlin/TestCoreService.kt
+++ b/bot/admin/test/core/src/main/kotlin/TestCoreService.kt
@@ -210,7 +210,10 @@ class TestCoreService : TestService {
         }
     }
 
+    // TODO MASS : to be deleted with DERCBOT-321
     private fun getDebugLog(conf: BotApplicationConfiguration): ScenarioDebugResponse {
+        if(!debugEnabled) return ScenarioDebugResponse(imgBase64 = "")
+
         val restClient = getRestClient(conf)
         val response = restClient.getDebugLog(conf.path ?: conf.applicationId)
 

--- a/bot/dialog-manager/core/src/main/kotlin/ai/tock/bot/processor/TickStoryProcessor.kt
+++ b/bot/dialog-manager/core/src/main/kotlin/ai/tock/bot/processor/TickStoryProcessor.kt
@@ -25,7 +25,8 @@ import ai.tock.shared.booleanProperty
 import mu.KotlinLogging
 import java.util.Stack
 
-val debugEnabled = booleanProperty("tock_bot_dialog_manager_debug_enabled", true)
+// TODO MASS : to be deleted with DERCBOT-321
+val debugEnabled = booleanProperty("tock_bot_dialog_manager_debug_enabled", false)
 
 /**
  * A processor of tick story, it orchestrates the use of the state machine and the solver.
@@ -118,7 +119,7 @@ class TickStoryProcessor(
         updateCurrentState(primaryObjective, secondaryObjective)
 
         if(debugEnabled) {
-            // TODO MASS à supprimer une fois le debug front est ok: c'est juste pour MAJ le graph
+            // TODO MASS (JIRA DERCBOT-321) à supprimer une fois le debug front est ok: c'est juste pour MAJ le graph
             GraphSolver.solve(
                 debugEnabled,
                 ranHandlers.lastOrNull(),

--- a/bot/engine/src/main/kotlin/engine/TockConnectorController.kt
+++ b/bot/engine/src/main/kotlin/engine/TockConnectorController.kt
@@ -81,8 +81,10 @@ internal class TockConnectorController constructor(
                     logger.info { "Register connector $connector for bot $bot" }
                     connector.register(this)
 
-                    // TODO MASS
-                    exposePythonLog()
+                    if(debugEnabled) {
+                        // TODO MASS: JIRA DERCBOT-321
+                        exposePythonLog()
+                    }
                 }
 
         internal fun unregister(


### PR DESCRIPTION
- Disable debugging by default
- Don't register temporary "dialog-manager" endpoint if debugging has not been enabled