### PR TITLE
Improvement : support resuming RAG experiments

### DIFF
--- a/gen-ai/orchestrator-server/src/main/python/tock-llm-indexing-tools/scripts/dataset/experiment/run_experiment.py
+++ b/gen-ai/orchestrator-server/src/main/python/tock-llm-indexing-tools/scripts/dataset/experiment/run_experiment.py
@@ -5,9 +5,12 @@ Usage:
     run_experiment.py [-v] --json-config-file=<jcf>
 
 Description:
+    This script is used to run an experiment on Langfuse dataset based on a json configuration file.
+    The configuration file specifies the RAG settings to use.
+    It builds a RAG chain from the RAG Query and runs it against the provided LangFuse dataset.
+    
     • If dataset_experiment.experiment_name in the JSON config already ends with a UUID the script resumes that existing experiment and
       skips items that are already present in the Langfuse run.
-
     • If it does not contain a UUID, a fresh experiment is started.
 
 Arguments:

--- a/gen-ai/orchestrator-server/src/main/python/tock-llm-indexing-tools/scripts/dataset/experiment/run_experiment.py
+++ b/gen-ai/orchestrator-server/src/main/python/tock-llm-indexing-tools/scripts/dataset/experiment/run_experiment.py
@@ -1,18 +1,20 @@
 """
-Run RAG experiment on Langfuse dataset
+Run or resume a RAG experiment on a Langfuse dataset.
 
 Usage:
     run_experiment.py [-v] --json-config-file=<jcf>
 
 Description:
-    This script is used to run an experiment on Langfuse dataset based on a json configuration file.
-    The configuration file specifies the RAG settings to use.
-    It builds a RAG chain from the RAG Query and runs it against the provided LangFuse dataset.
+    • If *dataset_experiment.experiment_name* in the JSON config **already ends with a UUID
+      (the pattern “-XXXXXXXX”)**, the script resumes that existing experiment and
+      skips items that are already present in the Langfuse run.
 
+    • If it **does not** contain a UUID, a fresh experiment is started: the script
+      appends “-XXXXXXXX” (first 8 chars of a new UUID-4) to the name exactly like
+      the previous version.
 
 Arguments:
     --json-config-file=<jcf>   Path to the input config file. This is a required argument.
-
 Options:
     -v                         Enable verbose output for debugging purposes. If not set, the script runs silently except for errors.
     -h, --help                 Display this help message and exit.
@@ -22,6 +24,7 @@ Examples:
     python run_experiment.py --json-config-file=path/to/config-file.json
 """
 import asyncio
+import re
 import time
 from datetime import datetime
 from typing import List, Optional
@@ -32,6 +35,7 @@ from gen_ai_orchestrator.routers.requests.requests import RagQuery
 from gen_ai_orchestrator.services.langchain.rag_chain import create_rag_chain, execute_rag_chain
 from gen_ai_orchestrator.services.security.security_service import fetch_secret_key_value
 from langfuse import Langfuse
+from langfuse.api import NotFoundError
 from langfuse.client import DatasetItemClient
 
 from scripts.common.logging_config import configure_logging
@@ -39,7 +43,9 @@ from scripts.common.models import StatusWithReason, ActivityStatus
 from scripts.dataset.evaluation.models import DatasetExperiment
 from scripts.dataset.experiment.models import RunExperimentInput, RunExperimentOutput
 
-async def main():
+UUID_SUFFIX_RE = re.compile(r".*-[0-9a-fA-F]{8}$")
+
+async def main() -> None:
     start_time = datetime.now()
     cli_args = docopt(__doc__, version='Run Experiment 1.0.0')
     logger = configure_logging(cli_args)
@@ -48,24 +54,59 @@ async def main():
     dataset_items: List[DatasetItemClient] = []
     tested_items: List[DatasetItemClient] = []
     rag_query: Optional[RagQuery] = None
-    try:
-        logger.info("Loading input data...")
-        input_config = RunExperimentInput.from_json_file(cli_args['--json-config-file'])
-        dataset_experiment = input_config.dataset_experiment
-        experiment_name = f'{dataset_experiment.experiment_name}-{str(uuid4())[:8]}'
-        dataset_experiment.experiment_name=experiment_name
-        logger.debug(f"\n{input_config.format()}")
 
-        rag_query=input_config.rag_query
+    try:
+        logger.info("Loading input data…")
+        input_config = RunExperimentInput.from_json_file(cli_args["--json-config-file"])
+        dataset_experiment = input_config.dataset_experiment
+
+        base_name = dataset_experiment.experiment_name
+        resume_run = bool(UUID_SUFFIX_RE.fullmatch(base_name))
+
+        if resume_run:
+            experiment_name = base_name
+            logger.info("Detected UUID in experiment name – will resume '%s'.", experiment_name)
+        else:
+            experiment_name = f"{base_name}-{str(uuid4())[:8]}"
+            logger.info("Starting new experiment '%s'.", experiment_name)
+
+        dataset_experiment.experiment_name = experiment_name
+        rag_query = input_config.rag_query
+
         client = Langfuse(
             host=str(rag_query.observability_setting.url),
             public_key=rag_query.observability_setting.public_key,
             secret_key=fetch_secret_key_value(rag_query.observability_setting.secret_key),
         )
+
         dataset = client.get_dataset(dataset_experiment.dataset_name)
         dataset_items = dataset.items
 
+        processed_item_ids = set()
+        if resume_run:
+            try:
+                dataset_run = client.get_dataset_run(
+                    dataset_name=dataset_experiment.dataset_name,
+                    dataset_run_name=experiment_name,
+                )
+                processed_item_ids = {ri.dataset_item_id for ri in dataset_run.dataset_run_items}
+                logger.info(
+                    "Found existing run with %d processed items (will skip them).",
+                    len(processed_item_ids),
+                )
+            except NotFoundError:
+                logger.warning(
+                    "No existing run named '%s' found – starting a fresh run.",
+                    experiment_name,
+                )
+                processed_item_ids.clear()
+                resume_run = False
+
         for item in dataset_items:
+            if item.id in processed_item_ids:
+                logger.debug("Skipping item %s (already processed).", item.id)
+                continue
+
             handler = item.get_langchain_handler(
                 run_name=experiment_name,
                 run_description=dataset_experiment.experiment_description,
@@ -86,17 +127,22 @@ async def main():
             )
 
             rag_query.question_answering_prompt.inputs["question"] = item.input["question"]
-            await execute_rag_chain(query=rag_query,debug=False, custom_observability_handler=handler)
+            await execute_rag_chain(query=rag_query, debug=False, custom_observability_handler=handler)
             tested_items.append(item)
 
             print(f'Item:{item.id} - Trace:{handler.get_trace_url()}')
             print(f'Waiting for rate limit delay ({input_config.rate_limit_delay}s)...')
-            time.sleep(input_config.rate_limit_delay)
+            await asyncio.sleep(input_config.rate_limit_delay)
+
         client.flush()
         activity_status = StatusWithReason(status=ActivityStatus.COMPLETED)
+
     except Exception as e:
         full_exception_name = f"{type(e).__module__}.{type(e).__name__}"
-        activity_status = StatusWithReason(status=ActivityStatus.FAILED, status_reason=f"{full_exception_name} : {e}")
+        activity_status = StatusWithReason(
+            status=ActivityStatus.FAILED,
+            status_reason=f"{full_exception_name} : {e}",
+        )
         logger.error(e, exc_info=True)
 
     len_dataset_items = len(dataset_items)
@@ -112,4 +158,3 @@ async def main():
 
 if __name__ == '__main__':
     asyncio.run(main())
-

--- a/gen-ai/orchestrator-server/src/main/python/tock-llm-indexing-tools/scripts/dataset/experiment/run_experiment.py
+++ b/gen-ai/orchestrator-server/src/main/python/tock-llm-indexing-tools/scripts/dataset/experiment/run_experiment.py
@@ -45,7 +45,7 @@ from scripts.dataset.experiment.models import RunExperimentInput, RunExperimentO
 
 UUID_SUFFIX_RE = re.compile(r".*-[0-9a-fA-F]{8}$")
 
-async def main() -> None:
+async def main():
     start_time = datetime.now()
     cli_args = docopt(__doc__, version='Run Experiment 1.0.0')
     logger = configure_logging(cli_args)
@@ -56,8 +56,8 @@ async def main() -> None:
     rag_query: Optional[RagQuery] = None
 
     try:
-        logger.info("Loading input data…")
-        input_config = RunExperimentInput.from_json_file(cli_args["--json-config-file"])
+        logger.info("Loading input data...")
+        input_config = RunExperimentInput.from_json_file(cli_args['--json-config-file'])
         dataset_experiment = input_config.dataset_experiment
 
         base_name = dataset_experiment.experiment_name
@@ -139,10 +139,7 @@ async def main() -> None:
 
     except Exception as e:
         full_exception_name = f"{type(e).__module__}.{type(e).__name__}"
-        activity_status = StatusWithReason(
-            status=ActivityStatus.FAILED,
-            status_reason=f"{full_exception_name} : {e}",
-        )
+        activity_status = StatusWithReason(status=ActivityStatus.FAILED, status_reason=f"{full_exception_name} : {e}")
         logger.error(e, exc_info=True)
 
     len_dataset_items = len(dataset_items)

--- a/gen-ai/orchestrator-server/src/main/python/tock-llm-indexing-tools/scripts/dataset/experiment/run_experiment.py
+++ b/gen-ai/orchestrator-server/src/main/python/tock-llm-indexing-tools/scripts/dataset/experiment/run_experiment.py
@@ -5,13 +5,10 @@ Usage:
     run_experiment.py [-v] --json-config-file=<jcf>
 
 Description:
-    • If *dataset_experiment.experiment_name* in the JSON config **already ends with a UUID
-      (the pattern “-XXXXXXXX”)**, the script resumes that existing experiment and
+    • If dataset_experiment.experiment_name in the JSON config already ends with a UUID the script resumes that existing experiment and
       skips items that are already present in the Langfuse run.
 
-    • If it **does not** contain a UUID, a fresh experiment is started: the script
-      appends “-XXXXXXXX” (first 8 chars of a new UUID-4) to the name exactly like
-      the previous version.
+    • If it does not contain a UUID, a fresh experiment is started.
 
 Arguments:
     --json-config-file=<jcf>   Path to the input config file. This is a required argument.


### PR DESCRIPTION
- Detects if experiment_name ends with a UUID to resume existing runs.
- Skips already processed dataset items when resuming.
- Falls back to creating a new run if none exists.