### PR TITLE
Fix evaluation/experiment scripts

### DIFF
--- a/gen-ai/orchestrator-server/src/main/python/server/src/gen_ai_orchestrator/services/langchain/rag_chain.py
+++ b/gen-ai/orchestrator-server/src/main/python/server/src/gen_ai_orchestrator/services/langchain/rag_chain.py
@@ -129,7 +129,9 @@ async def execute_rag_chain(
     conversational_retrieval_chain = create_rag_chain(request=request)
 
     message_history = ChatMessageHistory()
-    metadata = {}
+    session_id = None
+    user_id = None
+    tags = []
 
     if request.dialog:
         for msg in request.dialog.history:

--- a/gen-ai/orchestrator-server/src/main/python/tock-llm-indexing-tools/scripts/dataset/evaluation/ragas_evaluator.py
+++ b/gen-ai/orchestrator-server/src/main/python/tock-llm-indexing-tools/scripts/dataset/evaluation/ragas_evaluator.py
@@ -16,7 +16,7 @@ import json
 import logging
 import math
 import time
-from typing import List
+from typing import Any, List
 
 from langfuse._client.datasets import DatasetItemClient
 from langfuse.api import TraceWithFullDetails
@@ -70,6 +70,40 @@ class RagasEvaluator:
             metric.init(run_config)
             logger.debug(f"Init run configuration of '{metric.name}'")
 
+    def _coerce_text(self, value: Any) -> str:
+        if isinstance(value, str):
+            return value
+
+        if isinstance(value, dict):
+            for key in ('answer', 'display_answer', 'content', 'text', 'message'):
+                candidate = value.get(key)
+                if isinstance(candidate, str):
+                    return candidate
+
+            content = value.get('content')
+            if isinstance(content, list):
+                text_parts = [
+                    entry.get('text')
+                    for entry in content
+                    if isinstance(entry, dict) and isinstance(entry.get('text'), str)
+                ]
+                if text_parts:
+                    return '\n'.join(text_parts)
+
+            return json.dumps(value, ensure_ascii=False)
+
+        if isinstance(value, list):
+            text_parts = [entry for entry in value if isinstance(entry, str)]
+            if text_parts:
+                return '\n'.join(text_parts)
+
+            return json.dumps(value, ensure_ascii=False)
+
+        if value is None:
+            return ''
+
+        return str(value)
+
     def fetch_statements_reasons(self, trace_id):
         time.sleep(3)  # Waiting for trace update
         trace_full = self.langfuse_client.api.trace.get(trace_id)
@@ -107,10 +141,34 @@ class RagasEvaluator:
         run_trace_details: TraceWithFullDetails,
         experiment_name: str,
     ) -> List[MetricScore]:
-        query = item.input['question']
-        chunks = [doc['page_content'] for doc in run_trace_details.output['documents']]
-        answer = run_trace_details.output['answer']
-        ground_truth = item.expected_output.get('answer') or ''
+        trace_output = run_trace_details.output or {}
+        query = self._coerce_text(
+            item.input.get('question') if isinstance(item.input, dict) else item.input
+        )
+
+        raw_documents = (
+            trace_output.get('documents', [])
+            if isinstance(trace_output, dict)
+            else []
+        )
+        if not isinstance(raw_documents, list):
+            raw_documents = []
+
+        chunks = []
+        for doc in raw_documents:
+            page_content = doc.get('page_content') if isinstance(doc, dict) else None
+            if isinstance(page_content, str):
+                chunks.append(page_content)
+
+        answer = self._coerce_text(
+            trace_output.get('answer') if isinstance(trace_output, dict) else None
+        )
+        expected_answer = (
+            item.expected_output.get('answer')
+            if isinstance(item.expected_output, dict)
+            else item.expected_output
+        )
+        ground_truth = self._coerce_text(expected_answer)
 
         metric_scores: List[MetricScore] = []
         for m in self.metrics:

--- a/gen-ai/orchestrator-server/src/main/python/tock-llm-indexing-tools/scripts/dataset/evaluation/ragas_evaluator.py
+++ b/gen-ai/orchestrator-server/src/main/python/tock-llm-indexing-tools/scripts/dataset/evaluation/ragas_evaluator.py
@@ -20,7 +20,6 @@ from typing import Any, List
 
 from langfuse._client.datasets import DatasetItemClient
 from langfuse.api import TraceWithFullDetails
-from openai import NOT_GIVEN
 from ragas.dataset_schema import SingleTurnSample
 from ragas.embeddings import LangchainEmbeddingsWrapper
 from ragas.llms import LangchainLLMWrapper
@@ -48,23 +47,6 @@ class RagasEvaluator:
         em_factory = get_em_factory(setting=evaluation_input.em_setting)
 
         llm = llm_factory.get_language_model()
-        if hasattr(llm, 'reasoning_effort'):
-            # Older APIM gateways can reject this field for chat/completions.
-            llm.reasoning_effort = None
-        model_name = str(getattr(llm, 'model_name', '') or '').lower()
-        if 'gpt5' in model_name or 'gpt-5' in model_name:
-            # For GPT-5, align model with deployment and omit params commonly rejected by APIM.
-            deployment_name = getattr(llm, 'deployment_name', None)
-            if deployment_name:
-                llm.model_kwargs = {
-                    **getattr(llm, 'model_kwargs', {}),
-                    'model': deployment_name,
-                }
-            llm.model_kwargs = {
-                **getattr(llm, 'model_kwargs', {}),
-                'n': NOT_GIVEN,
-                'temperature': NOT_GIVEN,
-            }
         embedding = em_factory.get_embedding_model()
 
         self.observability_setting = evaluation_input.observability_setting
@@ -83,6 +65,11 @@ class RagasEvaluator:
             metric = metric_entry['metric']
             if isinstance(metric, MetricWithLLM):
                 metric.llm = LangchainLLMWrapper(llm)
+                # Ragas defaults to 1e-8 for single-completion calls, which can be
+                # rejected by some API gateways. Reuse the configured model temperature.
+                metric.llm.get_temperature = (
+                    lambda n, llm_temp=float(getattr(llm, 'temperature', 0.0) or 0.0): llm_temp
+                )
             if isinstance(metric, MetricWithEmbeddings):
                 metric.embeddings = LangchainEmbeddingsWrapper(embedding)
             metric.init(run_config)

--- a/gen-ai/orchestrator-server/src/main/python/tock-llm-indexing-tools/scripts/dataset/evaluation/ragas_evaluator.py
+++ b/gen-ai/orchestrator-server/src/main/python/tock-llm-indexing-tools/scripts/dataset/evaluation/ragas_evaluator.py
@@ -20,6 +20,7 @@ from typing import Any, List
 
 from langfuse._client.datasets import DatasetItemClient
 from langfuse.api import TraceWithFullDetails
+from openai import NOT_GIVEN
 from ragas.dataset_schema import SingleTurnSample
 from ragas.embeddings import LangchainEmbeddingsWrapper
 from ragas.llms import LangchainLLMWrapper
@@ -47,6 +48,23 @@ class RagasEvaluator:
         em_factory = get_em_factory(setting=evaluation_input.em_setting)
 
         llm = llm_factory.get_language_model()
+        if hasattr(llm, 'reasoning_effort'):
+            # Older APIM gateways can reject this field for chat/completions.
+            llm.reasoning_effort = None
+        model_name = str(getattr(llm, 'model_name', '') or '').lower()
+        if 'gpt5' in model_name or 'gpt-5' in model_name:
+            # For GPT-5, align model with deployment and omit params commonly rejected by APIM.
+            deployment_name = getattr(llm, 'deployment_name', None)
+            if deployment_name:
+                llm.model_kwargs = {
+                    **getattr(llm, 'model_kwargs', {}),
+                    'model': deployment_name,
+                }
+            llm.model_kwargs = {
+                **getattr(llm, 'model_kwargs', {}),
+                'n': NOT_GIVEN,
+                'temperature': NOT_GIVEN,
+            }
         embedding = em_factory.get_embedding_model()
 
         self.observability_setting = evaluation_input.observability_setting
@@ -105,19 +123,36 @@ class RagasEvaluator:
         return str(value)
 
     def fetch_statements_reasons(self, trace_id):
-        time.sleep(3)  # Waiting for trace update
-        trace_full = self.langfuse_client.api.trace.get(trace_id)
+        trace_full = None
+        for attempt in range(5):
+            try:
+                # Langfuse trace ingestion is async; trace can be temporarily unavailable.
+                time.sleep(3)
+                trace_full = self.langfuse_client.api.trace.get(trace_id)
+                break
+            except Exception as e:
+                if getattr(e, 'status_code', None) == 404 and attempt < 4:
+                    continue
+
+                return ''
+
+        if trace_full is None:
+            return ''
+
         observations = trace_full.observations
         last_gen_item = next(
             (obs for obs in reversed(observations) if obs.type == 'GENERATION'), None
         )
         if last_gen_item and last_gen_item.output:
-            parsed_data = json.loads(
-                last_gen_item.output['content'].strip('```json').strip('```')
-            )
-            logger.info(parsed_data.get('statements', []))
-            if parsed_data.get('statements', []):
-                return ' | '.join(parsed_data['statements'])
+            try:
+                parsed_data = json.loads(
+                    last_gen_item.output['content'].strip('```json').strip('```')
+                )
+                logger.info(parsed_data.get('statements', []))
+                if parsed_data.get('statements', []):
+                    return ' | '.join(parsed_data['statements'])
+            except Exception:
+                return ''
         return ''
 
     def calculate_metric_score(
@@ -180,7 +215,6 @@ class RagasEvaluator:
                 response=answer,
                 reference=ground_truth,
             )
-
             score, trace_id = self.calculate_metric_score(
                 metric, metric_name, sample, item, experiment_name
             )

--- a/gen-ai/orchestrator-server/src/main/python/tock-llm-indexing-tools/scripts/dataset/export/export_experiments.py
+++ b/gen-ai/orchestrator-server/src/main/python/tock-llm-indexing-tools/scripts/dataset/export/export_experiments.py
@@ -36,9 +36,11 @@ Examples:
     python export_experiments.py --json-config-file=path/to/config-file.json
 """
 
+import json
 import os
 import re
 from datetime import datetime
+from typing import Any
 
 from docopt import docopt
 from langfuse import Langfuse
@@ -138,7 +140,7 @@ def create_excel_output(
         for run_idx, run_name in enumerate(iterations):
             no_rag_count = 0
             for item in items:
-                answer = item.runs[run_idx].output.get('answer')
+                answer = extract_answer_text(item.runs[run_idx].output)
                 if answer == 'NO_RAG_ANSWER':
                     no_rag_count += 1
             if items:
@@ -166,18 +168,19 @@ def create_excel_output(
         col_letter = get_column_letter(
             10 + i
         )  # Start at col J (index 9 as indexes starts at 0 for letter A)
-        sheet[f"{col_letter}3"] = items[i].metadata.get('topic', '')
-        sheet[f"{col_letter}4"] = items[i].input.get('question', '')
-        sheet[f"{col_letter}5"] = items[i].expected_output.get('answer', '')
+        sheet[f"{col_letter}3"] = to_excel_text(items[i].metadata.get('topic', ''))
+        sheet[f"{col_letter}4"] = to_excel_text(items[i].input.get('question', ''))
+        sheet[f"{col_letter}5"] = to_excel_text(
+            items[i].expected_output.get('answer', '')
+        )
         for j in range(len(iterations)):
             start_row = 7 + 6 * j
-            sheet[f"{col_letter}{start_row}"] = (
-                items[i].runs[j].output.get('answer', '')
-            )
+            run_output = items[i].runs[j].output or {}
+            sheet[f"{col_letter}{start_row}"] = extract_answer_text(run_output)
             sheet[f"{col_letter}{start_row + 1}"] = '\n\n'.join(
                 [
                     format_document_for_excel(doc)
-                    for doc in items[i].runs[j].output.get('documents', [])
+                    for doc in run_output.get('documents', [])
                     if isinstance(doc, dict)
                 ]
             )
@@ -204,6 +207,31 @@ def sanitize_for_excel(text: str) -> str:
     text = ILLEGAL_EXCEL_CHARS.sub('', text)
 
     return text
+
+
+def to_excel_text(value: Any) -> str:
+    # openpyxl only accepts scalar values in a cell.
+    if value is None:
+        return ''
+    if isinstance(value, str):
+        return sanitize_for_excel(value)
+    if isinstance(value, (dict, list)):
+        return sanitize_for_excel(json.dumps(value, ensure_ascii=False))
+    return sanitize_for_excel(str(value))
+
+
+def extract_answer_text(output: dict | None) -> str:
+    if not isinstance(output, dict):
+        return to_excel_text(output)
+
+    answer = output.get('answer', '')
+    # In structured outputs, "answer" itself can be a JSON object.
+    if isinstance(answer, dict):
+        nested_answer = answer.get('answer')
+        if isinstance(nested_answer, str):
+            return to_excel_text(nested_answer)
+
+    return to_excel_text(answer)
 
 
 def format_document_for_excel(doc: dict) -> str:


### PR DESCRIPTION
  Changes:
  - In ragas_evaluator.py, normalize trace fields to plain text before creating SingleTurnSample.
  - Handle output.answer when it is a dict or list (not only string).

  Why:
  - After run_experiment.py, some Langfuse traces store answer as a structured object.
  - Ragas expects a text response, so evaluation could fail with a validation error.